### PR TITLE
Add support for metadata in the CSV data and defined in the options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,238 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:suggestion
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = true:suggestion
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = when_on_single_line:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = true:suggestion
+csharp_style_expression_bodied_methods = when_on_single_line:silent
+csharp_style_expression_bodied_operators = when_on_single_line:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+
+# Code-block preferences
+csharp_prefer_braces = when_multiline:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = false:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = false
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+[*.{cs,vb}]
+dotnet_style_operator_placement_when_wrapping = end_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion

--- a/Crowswood.CsvConverter.Tests/OptionsTests.cs
+++ b/Crowswood.CsvConverter.Tests/OptionsTests.cs
@@ -1,0 +1,133 @@
+﻿namespace Crowswood.CsvConverter.Tests
+{
+    [TestClass]
+    public class OptionsTests
+    {
+        [TestMethod]
+        public void ConstructorTest()
+        {
+            // Act
+            var options = new Options();
+
+            // Assert
+            Assert.IsNotNull(options, "Failed to create CSV Converter Options.");
+        }
+
+        [TestMethod]
+        public void InitialNoneTest()
+        {
+            // Act
+            var options = Options.None;
+
+            // Assert
+            Assert.IsNotNull(options, "Failed to generate 'Options.None'.");
+            Assert.AreEqual(0, options.OptionMembers.Length, "There should be no 'OptionMembers'.");
+            Assert.AreEqual(0, options.OptionMetadata.Length, "There should be no 'OptionsMetadata'.");
+            Assert.AreEqual(0, options.OptionTypes.Length, "There should be no 'OptionsTypes'.");
+        }
+
+        [TestMethod]
+        public void ModifyNoneTest()
+        {
+            // Arrange
+            var options = Options.None;
+
+            // Act
+            options.ForMember<Foo, int>(foo => foo.Id, "ID");
+            options.ForMetadata<Foo>("Foo", "Bar", "Baz");
+            options.ForType<Foo>();
+
+            // Assert
+            Assert.IsNotNull(options, "Failed to generate 'Options.None'.");
+            Assert.AreEqual(0, options.OptionMembers.Length, "There should be no 'OptionMembers'.");
+            Assert.AreEqual(0, options.OptionMetadata.Length, "There should be no 'OptionsMetadata'.");
+            Assert.AreEqual(0, options.OptionTypes.Length, "There should be no 'OptionsTypes'.");
+        }
+
+        [TestMethod]
+        public void CommentPrefixesTest()
+        {
+            // Arrange
+            var options = new Options();
+
+            // Assert
+            const string failureMessage = "Comment characters does not contain {0}.";
+            Assert.IsTrue(options.CommentPrefixes.Contains("!"), failureMessage, "exclamation mark");
+            Assert.IsTrue(options.CommentPrefixes.Contains("#"), failureMessage, "hash");
+            Assert.IsTrue(options.CommentPrefixes.Contains(";"), failureMessage, "semi-colon");
+            Assert.IsTrue(options.CommentPrefixes.Contains("//"), failureMessage, "double slash");
+            Assert.IsTrue(options.CommentPrefixes.Contains("--"), failureMessage, "double dash");
+        }
+
+        [TestMethod]
+        public void PropertyAndValuesPrefixesTest()
+        {
+            // Arrange
+            var options = new Options();
+
+            // Assert
+            Assert.AreEqual("Properties", options.PropertyPrefix, "Unexpected property prefix.");
+            Assert.AreEqual("Values", options.ValuesPrefix, "Unexpected values prefix.");
+        }
+
+        [TestMethod]
+        public void PrefixesCanBeChangedTest()
+        {
+            // Arrange
+            var options = new Options();
+
+            // Act
+            options.SetPrefixes("Foo", "Bar");
+            options.CommentPrefixes =
+                new[]
+                {
+                    "'",
+                };
+
+            // Assert
+            Assert.AreEqual("Foo", options.PropertyPrefix, "Unexpected property prefix.");
+            Assert.AreEqual("Bar", options.ValuesPrefix, "Unexpected values prefix.");
+            Assert.AreEqual(1, options.CommentPrefixes.Length, "Unexpected number of comment prefixes.");
+            Assert.IsTrue(options.CommentPrefixes.Contains("'"), "Unexpected comment prefix.");
+        }
+
+        [TestMethod]
+        public void StandardUseTest()
+        {
+            // Arrange
+            var options =
+                new Options()
+                    .ForType<Foo>()
+                    .ForMember<Foo, int>(foo => foo.Id, "ID")
+                    .ForMetadata<Bar>("Foo", "Bar", "Baz");
+
+            // Assert
+            Assert.AreEqual(1, options.OptionTypes.Length, "Unexpected number of Types.");
+            Assert.AreEqual(typeof(Foo), options.OptionTypes[0].Type, "Unexpected OptionTypes 0 Type.");
+
+            Assert.AreEqual(1, options.OptionMembers.Length, "Unexpected number of Members.");
+            Assert.AreEqual(typeof(Foo), options.OptionMembers[0].Type, "Unexpected OptionMembers 0 Type.");
+            Assert.AreEqual("ID", options.OptionMembers[0].Name, "Unexpected OptionMembers 0 Name.");
+            Assert.AreEqual(typeof(Foo).GetProperty("Id"), options.OptionMembers[0].Property, "Unexpected OptionMembers 0 Property.");
+
+            Assert.AreEqual(1, options.OptionMetadata.Length, "Unexpected number of Metadata.");
+            Assert.AreEqual(typeof(Bar), options.OptionMetadata[0].Type, "Unexpected OptionMetadata 0 Type.");
+            Assert.AreEqual("Foo", options.OptionMetadata[0].Prefix, "Unexpected OptionMetadata 0 Prefix.");
+            Assert.AreEqual(typeof(OptionMetadata<Bar>), options.OptionMetadata[0].GetType(), "Unexpected OptionMetadata 0 generic type.");
+            Assert.IsTrue(
+                ((OptionMetadata<Bar>)options.OptionMetadata[0]).PropertyNames
+                    .GroupBy(propertyName => propertyName)
+                    .ToDictionary(n => n.Key, n => n.Count())
+                    .All(kvp => (kvp.Key == "Bar" && kvp.Value == 1) ||
+                                (kvp.Key == "Baz" && kvp.Value == 1)),
+                "Unexpected OptionMetadata 0 PropertyNames.");
+        }
+
+        private class Foo
+        {
+            public int Id { get; set; }
+        }
+
+        private class Bar { }
+    }
+}

--- a/Crowswood.CsvConverter.sln
+++ b/Crowswood.CsvConverter.sln
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crowswood.CsvConverter.Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{66FF071E-BC8E-4102-BCD3-46C80932D653}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Crowswood.CsvConverter/Extensions/LinqExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/LinqExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace Crowswood.CsvConverter.Extensions
+{
+    /// <summary>
+    /// An extensions class to assist with LiNQ expressions.
+    /// </summary>
+    public static class LinqExtensions
+    {
+        /// <summary>
+        /// Return all the non-null elements from <paramref name="enumerable"/> as an <see cref="IEnumerable{T}"/>
+        /// of non-null <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the element.</typeparam>
+        /// <param name="enumerable">An <see cref="IEnumerable{T}"/> of nullable <typeparamref name="T"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of non-null <typeparamref name="T"/>.</returns>
+        public static IEnumerable<T> NotNull<T>(this IEnumerable<T?> enumerable) where T : class =>
+            enumerable
+                .Where(e => e != null)
+                .Select(e => e!);
+
+        /// <summary>
+        ///  Returns all the elements from <paramref name="source"/> once they have been 
+        ///  cast to <typeparamref name="TTarget"/> as an <see cref="IEnumerable{T}"/> of 
+        ///  <typeparamref name="TTarget"/> from <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the original data.</typeparam>
+        /// <typeparam name="TTarget">The type that the data is to be cast to.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> of <typeparamref name="TSource"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TTarget"/>.</returns>
+        public static IEnumerable<TTarget> NotNull<TSource, TTarget>(this IEnumerable<TSource> source)
+            where TSource : class
+            where TTarget : class =>
+            source
+                .Where(item => item is TTarget target && target != null)
+                .Cast<TTarget>();
+    }
+}

--- a/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+
+namespace Crowswood.CsvConverter.Extensions
+{
+    /// <summary>
+    /// An extensions class for the <see cref="Options"/> object hierarchy.
+    /// </summary>
+    public static class OptionsExtensions
+    {
+        /// <summary>
+        /// Retrieves the properties of the <seealso cref="OptionMetadata.Type"/> that match the
+        /// <seealso cref="OptionMetadata.PropertyNames"/>.
+        /// </summary>
+        /// <param name="optionMetadata">The <see cref="OptionMetadata"/> object.</param>
+        /// <returns>A <see cref="PropertyInfo"/> array.</returns>
+        public static PropertyInfo[] GetProperties(this OptionMetadata optionMetadata) =>
+            optionMetadata.Type.GetProperties()
+                .Where(property => optionMetadata.PropertyNames.Contains(property.Name))
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Extensions/ReflectionExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+
+namespace Crowswood.CsvConverter.Extensions
+{
+    /// <summary>
+    /// An extension class for <see cref="MethodInfo"/> extension methods to aid with reflection.
+    /// </summary>
+    public static class ReflectionExtensions
+    {
+        /// <summary>
+        /// Checks and returns whether the <paramref name="method"/> has arguments that match the
+        /// number and order of the specified <paramref name="types"/> and whether the return type
+        /// matches the specified <paramref name="returnType"/>.
+        /// </summary>
+        /// <param name="method">The <see cref="MethodInfo"/> object.</param>
+        /// <param name="types">A <see cref="Type"/> array.</param>
+        /// <param name="returnType">A <see cref="Type"/>.</param>
+        /// <returns>True if the types match the arguments and the return type matches; otherwise false.</returns>
+        public static bool CheckArguments(this MethodInfo method, Type[] types, Type returnType) =>
+            method.GetParameters().CheckArgumentTypes(types) &&
+            method.ReturnType.IsAssignableFrom(returnType);
+
+        /// <summary>
+        /// Checks whether the <paramref name="parameters"/> have types that match the specified
+        /// <paramref name="types"/>.
+        /// </summary>
+        /// <param name="parameters">The <see cref="ParameterInfo"/> array.</param>
+        /// <param name="types">A <see cref="Type"/> array.</param>
+        /// <returns>True if the number and order of the parameters and types match; false otherwise.</returns>
+        public static bool CheckArgumentTypes(this ParameterInfo[] parameters, Type[] types) =>
+            parameters.Length == types.Length &&
+            Enumerable
+                .Range(0, parameters.Length)
+                .All(index => parameters[index].ParameterType.IsAssignableFrom(types[index]));
+    }
+}

--- a/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Crowswood.CsvConverter.Extensions
+﻿using System.Reflection;
+
+namespace Crowswood.CsvConverter.Extensions
 {
     /// <summary>
     /// An extension class for type extension methods.
@@ -13,6 +15,60 @@
         /// <returns>An <see cref="int"/>.</returns>
         public static int GetDepth(this Type type) =>
             type.BaseType is null ? 0 : type.BaseType.GetDepth() + 1;
+
+        /// <summary>
+        /// Extension method to return a fully constructed generic method from the <paramref name="type"/>
+        /// that has the specified <paramref name="name"/> and matches the specified <paramref name="bindingFlags"/>,
+        /// for the specified <paramref name="genericType"/> that matches the specified 
+        /// <paramref name="argumentTypes"/> and <paramref name="returnType"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which to return the method.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="bindingFlags">The <see cref="BindingFlags"/> to use.</param>
+        /// <param name="genericType">The <see cref="Type"/> of the generic type.</param>
+        /// <param name="argumentTypes">A <see cref="Type[]"/> containing the argument types.</param>
+        /// <param name="returnType">The <see cref="Type"/> of the return type.</param>
+        /// <returns>A <see cref="MethodInfo"/> or null if the method is not found or could not be constructed.</returns>
+        public static MethodInfo? GetGenericMethod(this Type type,
+                                                   string name,
+                                                   BindingFlags bindingFlags,
+                                                   Type genericType,
+                                                   Type[] argumentTypes,
+                                                   Type returnType) =>
+            type.GetGenericMethod(name, bindingFlags, new[] { genericType }, argumentTypes, returnType);
+
+        /// <summary>
+        /// Extension method to return a fully constructed generic method from the <paramref name="type"/>
+        /// that has the specified <paramref name="name"/> and matches the specified <paramref name="bindingFlags"/>,
+        /// for the specified <paramref name="genericTypes"/> that matches the specified 
+        /// <paramref name="argumentTypes"/> and <paramref name="returnType"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which to return the method.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="bindingFlags">The <see cref="BindingFlags"/> to use.</param>
+        /// <param name="genericTypes">A <see cref="Type[]"/> containing the generic types.</param>
+        /// <param name="argumentTypes">A <see cref="Type[]"/> containing the argument types.</param>
+        /// <param name="returnType">The <see cref="Type"/> of the return type.</param>
+        /// <returns>A <see cref="MethodInfo"/> or null if the method is not found or could not be constructed.</returns>
+        public static MethodInfo? GetGenericMethod(this Type type,
+                                                   string name,
+                                                   BindingFlags bindingFlags,
+                                                   Type[] genericTypes,
+                                                   Type[] argumentTypes,
+                                                   Type returnType)
+        {
+            var methods =
+                type.GetMethods(bindingFlags)
+                    .Where(method => method.Name == name)
+                    .Where(method => method.IsGenericMethod)
+                    .Where(method => method.GetGenericArguments().Length == genericTypes.Length)
+                    .Select(method => method.MakeGenericMethod(genericTypes))
+                    .Where(method => method.CheckArguments(argumentTypes, returnType))
+                    .ToList();
+            var method =
+                methods.Count == 1 ? methods.First() : null;
+            return method;
+        }
 
         /// <summary>
         /// Extension method to return the <see cref="Type"/> name in the standard readable form.
@@ -31,7 +87,7 @@
                         .Select(t => t.GetName());
                 var pos = type.Name.IndexOf('`');
                 var baseName =
-                    pos >= 0 ? type.Name.Substring(0, pos) : type.Name;
+                    pos >= 0 ? type.Name[..pos] : type.Name;
                 var name = $"{baseName}<{string.Join(",", names)}>";
                 return name;
             }

--- a/Crowswood.CsvConverter/Options/OptionMetadata.cs
+++ b/Crowswood.CsvConverter/Options/OptionMetadata.cs
@@ -1,0 +1,165 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter
+{
+    /// <summary>
+    /// An abstract class that contains information about the metadata that has been configured
+    /// to be expected.
+    /// </summary>
+    public abstract class OptionMetadata
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the prefix used within the CSV data to indicate the metadata record.
+        /// </summary>
+        public string Prefix { get; }
+        
+        /// <summary>
+        /// Gets the <see cref="string[]"/> containing the property names.
+        /// </summary>
+        public string[] PropertyNames { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Type"/> of object to create.
+        /// </summary>
+        public abstract Type Type { get; }
+
+        #endregion
+
+        #region Constructors
+
+        protected OptionMetadata(string prefix, params string[] propertyNames)
+        {
+            this.Prefix = prefix;
+            this.PropertyNames = propertyNames;
+        }
+
+        #endregion
+
+        #region Static factory creation methods
+
+        /// <summary>
+        /// Static factory method to create and return an instance of <see cref="OptionMetadata{T}"/>
+        /// for the specified <paramref name="prefix"/> and <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> that this instance handles.</typeparam>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
+        /// <returns>An <see cref="OptionMetadata{T}"/> instance.</returns>
+        /// <remarks>
+        /// The <paramref name="propertyNames"/> must match the name of the properties of 
+        /// <typeparamref name="T"/>.
+        /// </remarks>
+        public static OptionMetadata<T> Create<T>(string prefix, params string[] propertyNames)
+            where T : class, new() =>
+            propertyNames.All(name => typeof(T).GetProperty(name) != null)
+                ? new(prefix, propertyNames)
+                : throw new ArgumentException(
+                    $"The {nameof(propertyNames)} do not match the properties of '{typeof(T).Name}.");
+
+        /// <summary>
+        /// Static factory method to create and return an instance of <see cref="OptionMetadata"/> 
+        /// for <paramref name="genericType"/> with the specified <paramref name="prefix"/> and 
+        /// <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="genericType">The <see cref="Type"/> that this instance handles.</param>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
+        /// <returns>An <see cref="OptionMetadata"/> instance.</returns>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="genericType"/> is not a class with a parameterless constructor.
+        /// or If <paramref name="prefix"/>is null, empty or only white space.
+        /// or If <paramref name="propertyNames"/> is an empty array.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">If the create method for <see cref="OptionMetadata{T}"/> cannot be bound to.</exception>
+        /// <remarks>
+        /// Uses reflection to find and invoke the generic <seealso cref="Create{T}(string, string[])"/>
+        /// method.
+        /// </remarks>
+        public static OptionMetadata Create(Type genericType, string prefix, params string[] propertyNames)
+        {
+            if (!genericType.IsClass || genericType.GetConstructor(Array.Empty<Type>()) is null)
+                throw new ArgumentException(
+                    $"'{genericType.Name}' must be a reference type with a parameterless constructor.",
+                    nameof(genericType));
+            if (string.IsNullOrWhiteSpace(prefix))
+                throw new ArgumentException(
+                    $"'{nameof(prefix)}' must be non-null, non-empty and non-whitespace.",
+                    nameof(prefix));
+            if (propertyNames.Length == 0)
+                throw new ArgumentException(
+                    $"'{nameof(propertyNames)}' must not be an empty array.",
+                    nameof(propertyNames));
+
+            var myType = typeof(OptionMetadata);
+            const string methodName = "Create";
+
+            var parameters =
+                new object[]
+                {
+                    prefix,
+                    propertyNames,
+                };
+            var argumentTypes =
+                parameters
+                    .Select(parameter => parameter.GetType())
+                    .ToArray();
+            var returnType = myType.MakeGenericType(genericType);
+
+            var method =
+                myType.GetGenericMethod(methodName,
+                                        BindingFlags.Public |
+                                        BindingFlags.Static,
+                                        genericType, argumentTypes, returnType);
+            var result = (OptionMetadata?)
+                method?.Invoke(null, parameters) ??
+                throw new InvalidOperationException($"Failed to bind to '{methodName}' for '{genericType.Name}'.");
+            return result;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Create an instance of the generic type.
+        /// </summary>
+        /// <returns></returns>
+        public abstract object CreateInstance();
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A sealed generic class that contains information about a specific type of metadata that has
+    /// been configured.
+    /// </summary>
+    /// <typeparam name="T">The type of object to be created.</typeparam>
+    public sealed class OptionMetadata<T> : OptionMetadata
+        where T : class, new()
+    {
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override Type Type => typeof(T);
+
+        #endregion
+
+        #region Constructors
+
+        public OptionMetadata(string prefix, params string[] propertyNames)
+            : base(prefix, propertyNames) { }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc/>
+        public override object CreateInstance() => new T();
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -11,6 +11,7 @@ namespace Crowswood.CsvConverter
         #region Fields
 
         private readonly List<OptionMember> optionMembers = new();
+        private readonly List<OptionMetadata> optionMetadata = new();
         private readonly List<OptionType> optionTypes = new();
         private readonly bool none;
 
@@ -24,12 +25,6 @@ namespace Crowswood.CsvConverter
         public static Options None => new(true);
 
         /// <summary>
-        /// Gets the <see cref="OptionMember"/> instances assigned to the current <see cref="Options"/>
-        /// instance.
-        /// </summary>
-        public OptionMember[] OptionMembers => optionMembers.ToArray();
-
-        /// <summary>
         /// Gets and sets the <see cref="string"/> array of comment prefixes.
         /// </summary>
         /// <remarks>
@@ -37,6 +32,18 @@ namespace Crowswood.CsvConverter
         /// be ignored.
         /// </remarks>
         public string[] CommentPrefixes { get; set; } = new[] { "!", "#", ";", "//", "--", };
+
+        /// <summary>
+        /// Gets the <see cref="OptionMember"/> instances assigned to the current <see cref="Options"/>
+        /// instance.
+        /// </summary>
+        public OptionMember[] OptionMembers => optionMembers.ToArray();
+
+        /// <summary>
+        /// Gets the <see cref="OptionMetadata"/> instances assigned to the <see cref="Options"/>
+        /// instance.
+        /// </summary>
+        public OptionMetadata[] OptionMetadata => optionMetadata.ToArray();
 
         /// <summary>
         /// Gets the <see cref="OptionType"/> instances assigned to the curent <see cref="Options"/>
@@ -86,6 +93,26 @@ namespace Crowswood.CsvConverter
             AddOptionMember(new OptionMember<TObject, TMember>(member, name));
 
         /// <summary>
+        /// Adds the specified <paramref name="optionMetadata"/>.
+        /// </summary>
+        /// <param name="optionMetadata">An <see cref="OptionMetadata"/> to add.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForMetadata<TMetadata>(OptionMetadata<TMetadata> optionMetadata)
+            where TMetadata : class, new() => AddOptionMetadata(optionMetadata);
+
+        /// <summary>
+        /// Adds a new <see cref="OptionMetadata{T}"/> for the specified <paramref name="prefix"/>
+        /// and <paramref name="propertyNames"/>
+        /// </summary>
+        /// <typeparam name="TMetadata">The generic parameter of the <see cref="OptionMetadata{T}"/>.</typeparam>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForMetadata<TMetadata>(string prefix, params string[] propertyNames)
+            where TMetadata : class, new() =>
+            ForMetadata(new OptionMetadata<TMetadata>(prefix, propertyNames));
+
+        /// <summary>
         /// Adss the specified <paramref name="optionType"/>.
         /// </summary>
         /// <typeparam name="TObject">The type that the <see cref="OptionType"/> is for.</typeparam>
@@ -116,6 +143,22 @@ namespace Crowswood.CsvConverter
             where TObject : class, new() =>
             ForType(new OptionType<TObject>(name));
 
+        /// <summary>
+        /// Sets the <seealso cref="PropertyPrefix"/> and <seealso cref="ValuesPrefix"/> according
+        /// to the specified <paramref name="propertiesPrefix"/> and <paramref name="valuesPrefix"/>.
+        /// </summary>
+        /// <param name="propertiesPrefix">A <see cref="string"/> containing the new properties prefix value or null for no change.</param>
+        /// <param name="valuesPrefix">A <see cref="string"/> containing the new values prefix value or null for no change.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options SetPrefixes(string? propertiesPrefix, string? valuesPrefix)
+        {
+            if (!string.IsNullOrWhiteSpace(propertiesPrefix))
+                this.PropertyPrefix = propertiesPrefix;
+            if (!string.IsNullOrWhiteSpace(valuesPrefix))
+                this.ValuesPrefix = valuesPrefix;
+            return this;
+        }
+
         #endregion
 
         #region Support routines
@@ -125,6 +168,14 @@ namespace Crowswood.CsvConverter
         {
             if (!none)
                 this.optionMembers.Add(optionMember);
+            return this;
+        }
+
+        private Options AddOptionMetadata<TMetadata>(OptionMetadata<TMetadata> optionMetadata)
+            where TMetadata : class, new()
+        {
+            if (!this.none)
+                this.optionMetadata.Add(optionMetadata);
             return this;
         }
 


### PR DESCRIPTION
Add extension methods for LINQ, Options and Reflection. Add OptionsMetadata class. Add ForMetadata method to Options. Add Metadata property to Converter. Add Options tests.