### PR TITLE
[BUG] metadata of dictionary not being handled correctly

### DIFF
--- a/Crowswood.CsvConverter.Tests/ConverterTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests.cs
@@ -442,6 +442,102 @@ Values,Foo,1,""Fred"",TestEnum.Data";
                 "Failed to reject options with metadata that defines invalid property names.");
         }
 
+        [TestMethod]
+        public void MetadataDictionaryNotNullDeserializeTest()
+        {
+            // Arrange
+            var text = @"
+Metadata,Foo,""Bert"",,""""
+Properties,Foo,Id,Name
+Values,Foo,1,""Fred""";
+
+            var options =
+                new Options()
+                    .ForType<Foo>()
+                    .ForMetadata("Metadata", false, "Name", "Value1", "Value2");
+
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize<Foo>(text);
+
+            // Assert
+            Assert.IsTrue(converter.Metadata.Any(), "No meta-data.");
+            Assert.IsTrue(converter.Metadata.ContainsKey(typeof(Foo)), "No meta-data for Foo.");
+            Assert.IsTrue(converter.Metadata[typeof(Foo)].Any(), "Empty meta-data for Foo.");
+
+            var metadata =
+                converter.Metadata[typeof(Foo)]
+                    .NotNull<object, Dictionary<string, string?>>()
+                    .FirstOrDefault();
+            Assert.IsNotNull(metadata, "No dictionary meta-data for Foo.");
+            Assert.IsInstanceOfType(metadata, typeof(Dictionary<string, string?>),
+                "The meta-data is not the expected type.");
+
+            Assert.IsNotNull(metadata,
+                "No dictionary meta-data for Foo.");
+            Assert.IsTrue(metadata.ContainsKey("Name"),
+                "Dictionary meta-data for Foo does not contain 'Name'.");
+            Assert.IsTrue(metadata.ContainsKey("Value1"),
+                "Dictionary meta-data for Foo does not contain 'Value1'.");
+            Assert.IsTrue(metadata.ContainsKey("Value2"),
+                "Dictionary meta-data for Foo does not contain 'Value2'.");
+            Assert.AreEqual("Bert", metadata["Name"],
+                "Dictionary meta-data for Foo has unexpected value for 'Name'.");
+            Assert.AreEqual("", metadata["Value1"],
+                "Dictionary meta-data for Foo has unexpected value for 'Value1'.");
+            Assert.AreEqual("", metadata["Value2"],
+                "Dictionary meta-data for Foo has unexpected value for 'Value2'.");
+        }
+
+        [TestMethod]
+        public void MetadataDictionaryNullableDeserializeTest()
+        {
+            // Arrange
+            var text = @"
+Metadata,Foo,""Bert"",,""""
+Properties,Foo,Id,Name
+Values,Foo,1,""Fred""";
+
+            var options =
+                new Options()
+                    .ForType<Foo>()
+                    .ForMetadata("Metadata", true, "Name", "Value1", "Value2");
+
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize<Foo>(text);
+
+            // Assert
+            Assert.IsTrue(converter.Metadata.Any(), "No meta-data.");
+            Assert.IsTrue(converter.Metadata.ContainsKey(typeof(Foo)), "No meta-data for Foo.");
+            Assert.IsTrue(converter.Metadata[typeof(Foo)].Any(), "Empty meta-data for Foo.");
+
+            var metadata =
+                converter.Metadata[typeof(Foo)]
+                    .NotNull<object, Dictionary<string, string?>>()
+                    .FirstOrDefault();
+            Assert.IsNotNull(metadata, "No dictionary meta-data for Foo.");
+            Assert.IsInstanceOfType(metadata, typeof(Dictionary<string, string?>), 
+                "The meta-data is not the expected type.");
+
+            Assert.IsNotNull(metadata,
+                "No dictionary meta-data for Foo.");
+            Assert.IsTrue(metadata.ContainsKey("Name"),
+                "Dictionary meta-data for Foo does not contain 'Name'.");
+            Assert.IsTrue(metadata.ContainsKey("Value1"),
+                "Dictionary meta-data for Foo does not contain 'Value1'.");
+            Assert.IsTrue(metadata.ContainsKey("Value2"),
+                "Dictionary meta-data for Foo does not contain 'Value2'.");
+            Assert.AreEqual("Bert", metadata["Name"],
+                "Dictionary meta-data for Foo has unexpected value for 'Name'.");
+            Assert.AreEqual(null, metadata["Value1"],
+                "Dictionary meta-data for Foo has unexpected value for 'Value1'.");
+            Assert.AreEqual("", metadata["Value2"],
+                "Dictionary meta-data for Foo has unexpected value for 'Value2'.");
+        }
+
         #region Model classes
 
         public enum TestEnum

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -113,6 +113,21 @@ namespace Crowswood.CsvConverter
             ForMetadata(new OptionMetadata<TMetadata>(prefix, propertyNames));
 
         /// <summary>
+        /// Adds a new <see cref="OptionMetadataDictionary"/> for the specific <paramref name="prefix"/>
+        /// and <paramref name="propertyNames"/> with nulls being allowed or not through 
+        /// <paramref name="allowNulls"/>.
+        /// </summary>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix.</param>
+        /// <param name="allowNulls">True if null values are allowed; false otherwise.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForMetadata(string prefix, bool allowNulls,params string[] propertyNames)=>
+            AddOptionMetadata(new OptionMetadataDictionary(prefix, propertyNames) 
+            {
+                AllowNulls = allowNulls
+            });
+
+        /// <summary>
         /// Adss the specified <paramref name="optionType"/>.
         /// </summary>
         /// <typeparam name="TObject">The type that the <see cref="OptionType"/> is for.</typeparam>
@@ -171,8 +186,7 @@ namespace Crowswood.CsvConverter
             return this;
         }
 
-        private Options AddOptionMetadata<TMetadata>(OptionMetadata<TMetadata> optionMetadata)
-            where TMetadata : class, new()
+        private Options AddOptionMetadata(OptionMetadata optionMetadata)
         {
             if (!this.none)
                 this.optionMetadata.Add(optionMetadata);


### PR DESCRIPTION
Added new OptionMetadata class especially for the dictionary option, with AllowNulls flag to control whether the Value can be null or not. Replaced checks on OptionMetadata.Type for being Dictionary... with check for OptionMetadataDictionary. Add tests for dictionary metadata.