### PR TITLE
[REFACTOR] Add explicit typeless-data classes

### DIFF
--- a/Crowswood.CsvConverter/Model/Typeless.cs
+++ b/Crowswood.CsvConverter/Model/Typeless.cs
@@ -1,0 +1,11 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    internal abstract class Typeless
+    {
+    }
+
+    internal abstract class Typeless<T> : Typeless
+    {
+        public abstract T Get();
+    }
+}

--- a/Crowswood.CsvConverter/Model/TypelessData.cs
+++ b/Crowswood.CsvConverter/Model/TypelessData.cs
@@ -1,0 +1,49 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    internal class TypelessData : Typeless<(string[], IEnumerable<string[]>)>
+    {
+        private readonly List<TypelessValues> values = new();
+
+        public TypelessNames Names { get; }
+
+        public IEnumerable<TypelessValues> Values => this.values;
+
+        public string this[int index, string field]
+        {
+            get => this.values[index][this.Names[field]];
+            set => this.values[index][this.Names[field]] = value;
+        }
+
+        public string this[string field, int index]
+        {
+            get => this[index, field];
+            set => this[index, field] = value;
+        }
+
+        public TypelessData(string[] names) => this.Names = new TypelessNames(names);
+
+        public TypelessData(string[] names, IEnumerable<string[]> values)
+            : this(names)
+        {
+            if (values.Any(v => v.Length != names.Length))
+                throw new ArgumentException(
+                    "All values must have the same number of items as the names.",
+                    nameof(values));
+
+            this.values.AddRange(
+                values
+                    .Select(v => new TypelessValues(v)));
+        }
+
+        public void Add(string[] values)
+        {
+            if (values.Length != this.Names.Length)
+                throw new ArgumentException("The number of values must match the number of names.",
+                    nameof(values));
+            this.values.Add(new TypelessValues(values));
+        }
+
+        public override (string[], IEnumerable<string[]>) Get() =>
+            (this.Names.Get(), this.Values.Select(v => v.Get().ToArray()));
+    }
+}

--- a/Crowswood.CsvConverter/Model/TypelessNames.cs
+++ b/Crowswood.CsvConverter/Model/TypelessNames.cs
@@ -1,0 +1,17 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    internal class TypelessNames : Typeless<string[]>
+    {
+        private readonly List<string> names = new();
+
+        public int Length => names.Count;
+
+        public string this[int index] => names[index];
+
+        public int this[string name] => this.names.IndexOf(name);
+
+        public TypelessNames(string[] names) => this.names.AddRange(names);
+
+        public override string[] Get() => this.names.ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Model/TypelessValues.cs
+++ b/Crowswood.CsvConverter/Model/TypelessValues.cs
@@ -1,0 +1,17 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    internal class TypelessValues : Typeless<string[]>
+    {
+        private readonly List<string> values = new();
+
+        public string this[int index]
+        {
+            get => values[index];
+            set => values[index] = value;
+        }
+
+        public TypelessValues(IEnumerable<string> values) => this.values.AddRange(values);
+
+        public override string[] Get() => this.values.ToArray();
+    }
+}


### PR DESCRIPTION
Add a set of typeless-data classes to simplify handing typeless-data. Base abstract Typeless with generic sub-class, then TypelessNames to hold the field names, TypelessValues to hold a row of values, finally Typelessdata to hold a set of field names and a list of values. Refactor the Converter class to use those instead of the explicit string[] types.