### PR TITLE
[FEATURE] Add options support for referencing other data types

### DIFF
--- a/Crowswood.CsvConverter.Tests/ConverterTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests.cs
@@ -364,6 +364,43 @@ Values,Foo,1,""Picture"",TestEnum.Data";
         }
 
         [TestMethod]
+        public void TypedInsufficientValuesDeserializationTest()
+        {
+            // Assign
+            var text = @"
+Properties,Foo,Id,Name,TestEnum
+Values,Foo,1,""Fred""
+";
+            var converter = new Converter(Options.None);
+
+            // Act
+            var data = converter.Deserialize<Foo>(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize data.");
+        }
+
+        [TestMethod]
+        public void TypelessInsufficientVauesDeserializationTest()
+        {
+            // Assign
+            var text = @"
+Properties,FooBar,Id,Name,OtherValue
+Values,FooBar,1,""Fred""
+";
+            var options =
+                new Options()
+                    .ForType("FooBar", "Id", "Name", "OtherValue");
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize data.");
+        }
+
+        [TestMethod]
         public void MetadataDeserializationTest()
         {
             // Arrange
@@ -869,7 +906,7 @@ Values,OtherFoo,#,#OtherFoo(""Alpha""),""Beta""
         }
 
         [TestMethod]
-        public void TypelessReferenceDatadeserializationTest()
+        public void TypelessReferenceDataDeserializationTest()
         {
             // Assign
             var text = @"
@@ -973,6 +1010,104 @@ Values,FooBar,#,#FooBar(""Alpha""),""Beta""
                 "Failed to find reference record: beta.");
         }
 
+        [TestMethod]
+        public void TypelessReferenceDataDeserializationOptionsTest()
+        {
+            // Assign
+            var text = @"
+Properties,FooBar,Id,Name,RefDataId,RefMeatId,RefVegId
+Values,FooBar,#,""Fred"",#ReferenceData(""Beta""),#ReferenceMeat(""Steak""),#ReferenceVeg(""Beans"")
+Values,FooBar,#,""Bert"",#ReferenceData(""Alpha""),#ReferenceMeat(""Chops""),#ReferenceVeg(""Peas"")
+
+Properties,ReferenceData,Identity,FullName
+Values,ReferenceData,#,""Alpha""
+Values,ReferenceData,#,""Beta""
+
+Properties,ReferenceMeat,Identity,OtherName
+Values,ReferenceMeat,#,""Steak""
+Values,ReferenceMeat,#,""Chops""
+
+Properties,ReferenceVeg,Id,Name
+Values,ReferenceVeg,#,""Peas""
+Values,ReferenceVeg,#,""Beans""";
+            var options =
+                new Options()
+                    .ForType("FooBar", "Id", "Name", "RefDataId", "RefMeatId", "RefVegId")
+                    .ForType("ReferenceData", "Identity", "FullName")
+                    .ForType("ReferenceMeat", "Identity", "OtherName")
+                    .ForType("ReferenceVeg", "Id", "Name")
+                    .ForReferences("Identity", "FullName")
+                    .ForReferences("ReferenceMeat", "Identity", "OtherName")
+                    .ForReferences("ReferenceVeg", "Id", "Name");
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize to typeless data.");
+            Assert.AreEqual(4, data.Count, "Unexpected number of data types.");
+
+            const string UNEXPECTED_NUMBER_ITEMS = "Unexpected number of items: {0}.";
+
+            var fooBarData = data["FooBar"];
+            Assert.AreEqual(2, fooBarData.Item2.Count(), UNEXPECTED_NUMBER_ITEMS, "FooBar");
+
+            var referenceDataData = data["ReferenceData"];
+            Assert.AreEqual(2, referenceDataData.Item2.Count(), UNEXPECTED_NUMBER_ITEMS, "ReferenceData");
+
+            var referenceMeatData = data["ReferenceMeat"];
+            Assert.AreEqual(2, referenceMeatData.Item2.Count(), UNEXPECTED_NUMBER_ITEMS, "ReferenceMeat");
+
+            var referenceVegData = data["ReferenceVeg"];
+            Assert.AreEqual(2, referenceVegData.Item2.Count(), UNEXPECTED_NUMBER_ITEMS, "ReferenceVeg");
+
+            var (fred, bert) = Get2Items(fooBarData, "Name", "Fred", "Bert");
+            var (alpha, beta) = Get2Items(referenceDataData, "FullName", "Alpha", "Beta");
+            var (steak, chops) = Get2Items(referenceMeatData, "OtherName", "Steak", "Chops");
+            var (peas, beans) = Get2Items(referenceVegData, "Name", "Peas", "Beans");
+
+            var fooBarRefDataIdIndex = getIndex(fooBarData, "RefDataId");
+            var fooBarRefMeatIdIndex = getIndex(fooBarData, "RefMeatId");
+            var fooBarRefVegIdIndex = getIndex(fooBarData, "RefVegId");
+            var referenceDataIdIndex = getIndex(referenceDataData, "Identity");
+            var referenceMeatIdIndex = getIndex(referenceMeatData, "Identity");
+            var referenceVegIdIndex = getIndex(referenceVegData, "Id");
+
+            const string UNEXPECTED_REFERENCE_VALUE = "Unexpected reference value for {0} in record {1}.";
+
+            Assert.AreEqual(beta[referenceDataIdIndex], fred[fooBarRefDataIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceData", "Fred");
+            Assert.AreEqual(steak[referenceMeatIdIndex], fred[fooBarRefMeatIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceMeat", "Fred");
+            Assert.AreEqual(beans[referenceVegIdIndex], fred[fooBarRefVegIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceVeg", "Fred");
+
+            Assert.AreEqual(alpha[referenceDataIdIndex], bert[fooBarRefDataIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceData", "Bert");
+            Assert.AreEqual(chops[referenceMeatIdIndex], bert[fooBarRefMeatIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceMeat", "Bert");
+            Assert.AreEqual(peas[referenceVegIdIndex], bert[fooBarRefVegIdIndex],
+                UNEXPECTED_REFERENCE_VALUE, "ReferenceVeg", "Bert");
+
+            (string[], string[]) Get2Items((string[], IEnumerable<string[]>) source, string fieldName, string item1Name, string item2Name)
+            {
+                var index = source.Item1.ToList().IndexOf(fieldName);
+                var item1Value=source.Item2.FirstOrDefault(item => item[index] == item1Name);
+                var item2Value = source.Item2.FirstOrDefault(item => item[index] == item2Name);
+
+                Assert.IsNotNull(item1Value, "Failed to find record: {0}", item1Name);
+                Assert.IsNotNull(item2Value, "Failed to find record: {0}", item2Name);
+
+                return (item1Value, item2Value);
+            }
+
+            int getIndex((string[], IEnumerable<string[]>) source, string indexName) => 
+                source.Item1.ToList().IndexOf(indexName);
+        }
+
+        #region Support routines
+
         private static void DynamicDeserializationImplementation(string text,
                                                                  string typeName, string[] propertyNames,
                                                                  string[] expectedNames,
@@ -992,7 +1127,7 @@ Values,FooBar,#,#FooBar(""Alpha""),""Beta""
             Assert.AreEqual(1, data.Count, "Unexpected number of data types.");
 
             var actualNames = data[typeName].Item1;
-            Assert.AreEqual(expectedNames.Length, actualNames.Length, 
+            Assert.AreEqual(expectedNames.Length, actualNames.Length,
                 "Unexpected number of {0} names.", typeName);
 
             for (var index = 0; index < expectedNames.Length; index++)
@@ -1000,15 +1135,15 @@ Values,FooBar,#,#FooBar(""Alpha""),""Beta""
                     "Unexpected name of {0} names {1}.", typeName, index);
 
             var actualValues = data[typeName].Item2;
-            Assert.AreEqual(expectedValues.Length, actualValues.Count(), 
+            Assert.AreEqual(expectedValues.Length, actualValues.Count(),
                 "Unexpected number of {0} values.", typeName);
 
-            for(var index = 0; index < expectedValues.Length; index++)
+            for (var index = 0; index < expectedValues.Length; index++)
             {
                 var actualValuesN = actualValues.Skip(index).First();
                 Assert.AreEqual(expectedValues[index].Length, actualValuesN.Length,
                     "Unexpected number of {0} {1} values.", typeName, index);
-                for(var innerIndex = 0; innerIndex < expectedValues[index].Length; innerIndex++)
+                for (var innerIndex = 0; innerIndex < expectedValues[index].Length; innerIndex++)
                     Assert.AreEqual(actualValuesN[innerIndex], expectedValues[index][innerIndex],
                         "Unexpected value of {0} {1} values {2}.", typeName, index, innerIndex);
             }
@@ -1035,6 +1170,8 @@ Values,FooBar,#,#FooBar(""Alpha""),""Beta""
             for (var index = 0; index < expectedValues.Length; index++)
                 Assert.IsTrue(text.Contains(expectedValues[index]), "Serialized text contains no values line {0}.", index);
         }
+
+        #endregion
 
         #region Model classes
 

--- a/Crowswood.CsvConverter.Tests/OptionsTests.cs
+++ b/Crowswood.CsvConverter.Tests/OptionsTests.cs
@@ -146,6 +146,42 @@
             Assert.AreEqual("Name", odt?.PropertyNames[1], "Unexpecte name for parameter 1.");
         }
 
+        [TestMethod]
+        public void RefernecesTest()
+        {
+            // Arrange
+            var options =
+                new Options()
+                    .ForReferences("AnId", "TheName")
+                    .ForReferences("Foo", "Identity", "FullName")
+                    .ForReferences<Bar>("ID", "AnotherName");
+
+            // Assert
+            Assert.AreEqual(3, options.OptionsReferences.Length, "Unexpected number of option references.");
+
+            ReferenceTestBody<OptionReference>("global", options, 0, null, "AnId", "TheName");
+            ReferenceTestBody<OptionReferenceType>("Foo", options, 1, "Foo", "Identity", "FullName");
+            ReferenceTestBody<OptionReferenceType<Bar>>("Bar", options, 2, "Bar", "ID", "AnotherName");
+        }
+
+        private static void ReferenceTestBody<T>(string name, Options options, int index, string? typeName, string idProperty, string nameProperty)
+            where T : OptionReference
+        {
+            Assert.IsInstanceOfType(options.OptionsReferences[index], typeof(T),
+                "Unexpected option reference: {0}.", name);
+
+            var reference = options.OptionsReferences[index] as T;
+
+            if (reference is OptionReferenceType optionReferenceType && typeName is not null)
+                Assert.AreEqual(typeName, optionReferenceType.TypeName,
+                    "Unexpected type name: {0}.", name);
+
+            Assert.AreEqual(idProperty, reference?.IdPropertyName,
+                "Unexpected Id property name: {0}.", name);
+            Assert.AreEqual(nameProperty, reference?.NamePropertyName,
+                "Unexpected Name property name: {0}.", name);
+        }
+
         #region Test model
 
         private class Foo

--- a/Crowswood.CsvConverter/Options/OptionReference.cs
+++ b/Crowswood.CsvConverter/Options/OptionReference.cs
@@ -1,0 +1,69 @@
+﻿namespace Crowswood.CsvConverter
+{
+    /// <summary>
+    /// A base class that allows the default names of the properties that should be used when 
+    /// referencing an entity.
+    /// </summary>
+    public class OptionReference
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets a <see cref="string"/> containing the name of the Id property.
+        /// </summary>
+        public string IdPropertyName { get; }
+
+        /// <summary>
+        /// Gets a <see cref="string"/> containing the name of the Name property.
+        /// </summary>
+        public string NamePropertyName { get; }
+
+        #endregion
+
+        #region Constructors
+
+        public OptionReference(string idPropertyName, string namePropertyName)
+        {
+            this.IdPropertyName = idPropertyName;
+            this.NamePropertyName = namePropertyName;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A derived class that allows the type of an entity object to be held together with the 
+    /// names of the properties that should be used when referencing that entity.
+    /// </summary>
+    public class OptionReferenceType : OptionReference
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets a <see cref="string"/> containing the name of the referenced type.
+        /// </summary>
+        public string TypeName { get; }
+
+        #endregion
+
+        #region Constructors
+
+        public OptionReferenceType(string typeName, string idPropertyName, string namePropertyName)
+            : base(idPropertyName, namePropertyName) => this.TypeName = typeName;
+
+        public OptionReferenceType(Type type, string idPropertyName, string namePropertyName)
+            : this(type.Name, idPropertyName, namePropertyName) { }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A derived generic class that allows an entity type to be specified using generics.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="Type"/> of entity object.</typeparam>
+    internal class OptionReferenceType<T> : OptionReferenceType
+    {
+        public OptionReferenceType(string idPropertyName, string namePropertyName)
+            : base(typeof(T), idPropertyName, namePropertyName) { }
+    }
+}

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -12,7 +12,9 @@ namespace Crowswood.CsvConverter
 
         private readonly List<OptionMember> optionMembers = new();
         private readonly List<OptionMetadata> optionMetadata = new();
+        private readonly List<OptionReference> optionsReferences = new();
         private readonly List<OptionType> optionTypes = new();
+
         private readonly bool none;
 
         #endregion
@@ -37,19 +39,25 @@ namespace Crowswood.CsvConverter
         /// Gets the <see cref="OptionMember"/> instances assigned to the current <see cref="Options"/>
         /// instance.
         /// </summary>
-        public OptionMember[] OptionMembers => optionMembers.ToArray();
+        internal OptionMember[] OptionMembers => optionMembers.ToArray();
 
         /// <summary>
         /// Gets the <see cref="OptionMetadata"/> instances assigned to the <see cref="Options"/>
         /// instance.
         /// </summary>
-        public OptionMetadata[] OptionMetadata => optionMetadata.ToArray();
+        internal OptionMetadata[] OptionMetadata => optionMetadata.ToArray();
+
+        /// <summary>
+        /// Gets the <see cref="OptionReferenceType"/> instances assigned to the current <see cref="Options"/> 
+        /// instance.
+        /// </summary>
+        internal OptionReference[] OptionsReferences => this.optionsReferences.ToArray();
 
         /// <summary>
         /// Gets the <see cref="OptionType"/> instances assigned to the curent <see cref="Options"/>
         /// instance.
         /// </summary>
-        public OptionType[] OptionTypes => optionTypes.ToArray();
+        internal OptionType[] OptionTypes => optionTypes.ToArray();
 
         /// <summary>
         /// Gets the <see cref="string"/> that contains the property prefix.
@@ -122,6 +130,39 @@ namespace Crowswood.CsvConverter
 
 
         /// <summary>
+        /// Adds a new <see cref="OptionReference"/> to define the reference defaults with the 
+        /// specified <paramref name="idPropertyName"/> and <paramref name="namePropertyName"/>.
+        /// </summary>
+        /// <param name="idPropertyName">A <see cref="string"/> containing the name of the Id property.</param>
+        /// <param name="namePropertyName">A <see cref="string"/> containing the name of the Name property.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForReferences(string idPropertyName, string namePropertyName) =>
+            AddReference(new OptionReference(idPropertyName, namePropertyName));
+
+        /// <summary>
+        /// Adds a new <see cref="OptionReferenceType"/> for the specified <paramref name="typeName"/> 
+        /// with the specified <paramref name="idPropertyName"/> and <paramref name="namePropertyName"/>.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
+        /// <param name="idPropertyName">A <see cref="string"/> containing the name of the Id property.</param>
+        /// <param name="namePropertyName">A <see cref="string"/> containing the name of the Name property.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForReferences(string typeName, string idPropertyName, string namePropertyName) =>
+            AddReference(new OptionReferenceType(typeName, idPropertyName, namePropertyName));
+
+        /// <summary>
+        /// Adds a new <see cref="OptionReferenceType{T}"/> for the specified <typeparamref name="T"/> 
+        /// with the specified <paramref name="idPropertyName"/> and <paramref name="namePropertyName"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of object that is being referenced.</typeparam>
+        /// <param name="idPropertyName">A <see cref="string"/> containing the name of the Id property.</param>
+        /// <param name="namePropertyName">A <see cref="string"/> containing the name of the Name property.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ForReferences<T>(string idPropertyName, string namePropertyName)=>
+            AddReference(new OptionReferenceType<T>(idPropertyName, namePropertyName));
+
+
+        /// <summary>
         /// Adds a new <see cref="OptionType{T}"/> for <typeparamref name="TObject"/> to the 
         /// current <see cref="Options"/> instance.
         /// </summary>
@@ -174,24 +215,21 @@ namespace Crowswood.CsvConverter
         #region Support routines
 
         private Options AddMember<TObject, TMember>(OptionMember<TObject, TMember> optionMember)
-            where TObject : class, new()
-        {
-            if (!none)
-                this.optionMembers.Add(optionMember);
-            return this;
-        }
+            where TObject : class, new() => Add(optionMember, this.optionMembers);
 
-        private Options AddMetadata(OptionMetadata optionMetadata)
+        private Options AddMetadata(OptionMetadata optionMetadata) =>
+            Add(optionMetadata, this.optionMetadata);
+
+        private Options AddReference(OptionReference optionReference) =>
+            Add(optionReference, this.optionsReferences);
+
+        private Options AddType(OptionType optionType) =>
+            Add(optionType, this.optionTypes);
+
+        private Options Add<T>(T item, List<T> items) where T : class
         {
             if (!this.none)
-                this.optionMetadata.Add(optionMetadata);
-            return this;
-        }
-
-        private Options AddType(OptionType optionType) 
-        {
-            if (!none)
-                optionTypes.Add(optionType);
+                items.Add(item);
             return this;
         }
 


### PR DESCRIPTION
Add OptionsRefernece type hierarchy.
Add methods to retrieve specified id and name column names for specified data type, falling back first to a global option, then to hard-coded values. Add option tests.

[TEST] Options for Referenced data

Add test for typeless referenced data.
Also fix index out of range problem when the number of value columns is less than the number of property columns. Added test to confirm fix for both typed and typeless data.