### PR TITLE
[FEATURE] Conversion support

### DIFF
--- a/Crowswood.CsvConverter.Tests/ConversionTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConversionTests.cs
@@ -1,0 +1,212 @@
+﻿using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.Model;
+
+namespace Crowswood.CsvConverter.Tests
+{
+    [TestClass]
+    public class ConversionTests
+    {
+        [TestMethod]
+        public void ConversionTypeTest()
+        {
+            // Arrange
+            var original = "Original";
+            var converted = "Converted";
+
+            // Act
+            var conversionType =
+                new ConversionType
+                {
+                    OriginalTypeName = original,
+                    ConvertedTypeName = converted
+                };
+
+            // Assert
+            Assert.IsNotNull(conversionType, "Failed to create ConversionType instance.");
+
+            Assert.AreEqual(original, conversionType.OriginalTypeName, "Unexpected original type name.");
+            Assert.AreEqual(converted, conversionType.ConvertedTypeName, "Unexpected converted type name.");
+        }
+
+        [TestMethod]
+        public void ConversionValueTest()
+        {
+            // Arrange
+            var original = "Original";
+            var converted = "Converted";
+
+            // Act
+            var conversionValue =
+                new ConversionValue
+                {
+                    OriginalValue = original,
+                    ConvertedValue = converted
+                };
+
+            // Assert
+            Assert.IsNotNull(conversionValue, "Failed to create ConversionType instance.");
+
+            Assert.AreEqual(original, conversionValue.OriginalValue, "Unexpected original value.");
+            Assert.AreEqual(converted, conversionValue.ConvertedValue, "Unexpected converted value.");
+        }
+
+        [TestMethod]
+        public void HandlerConstructorTest()
+        {
+            // Arrange
+            var text = @"
+ConversionType,OriginalType,NewType
+ConversionValue,Foo,Bar
+";
+            var options = Options.None;
+            var configHandler = new ConfigHandler(Options.None);
+            var lines = 
+                text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+
+            // Act
+            var conversionHandler = new ConversionHandler(options, configHandler, lines);
+
+            // Assert
+            Assert.IsNotNull(conversionHandler, "Failed to create ConversionHandler.");
+
+            Assert.AreEqual(1, conversionHandler.ConversionTypes.Length, "Unexpected number of ConversionTypes.");
+            Assert.AreEqual(1, conversionHandler.ConversionValues.Length, "Unexpected number of ConversionValues.");
+
+            var conversionType = conversionHandler.ConversionTypes[0];
+            Assert.AreEqual("OriginalType", conversionType.OriginalTypeName, "Unexpected ConversionType OriginalType.");
+            Assert.AreEqual("NewType", conversionType.ConvertedTypeName, "Unexpected ConversionType ConvertedType.");
+
+            var conversionValue = conversionHandler.ConversionValues[0];
+            Assert.AreEqual("Foo", conversionValue.OriginalValue, "Unexpected ConversionValue OriginalValue.");
+            Assert.AreEqual("Bar", conversionValue.ConvertedValue, "Unexpected ConversionValue ConvertedValue.");
+        }
+
+        [TestMethod]
+        public void OptionsNoneTest()
+        {
+            // Arrange
+
+            // Act
+            var options = Options.None;
+
+            // Assert
+            const string UNEXPECTED_STATE = "Unexpected {0} enabled state.";
+            const string UNEXPECTED_PREFIX = "Unexpected {0} prefix.";
+
+            Assert.AreEqual(false, options.IsTypeConversionEnabled, UNEXPECTED_STATE, "ConversionType");
+            Assert.AreEqual(false, options.IsValueConversionEnabled, UNEXPECTED_STATE, "ConversionValue");
+
+            Assert.AreEqual("ConversionType", options.ConversionTypePrefix, UNEXPECTED_PREFIX, "ConversionType");
+            Assert.AreEqual("ConversionValue", options.ConversionValuePrefix, UNEXPECTED_PREFIX, "ConversionValue");
+        }
+
+        [TestMethod]
+        #region Test data
+        [DataRow(false, DisplayName = "Disabled")]
+        [DataRow(true, DisplayName = "Enabled")]
+        #endregion
+        public void OptionsEnabledTogetherTest(bool enabledFlag)
+        {
+            // Arrange
+
+            // Act
+            var options =
+                new Options()
+                    .ConversionsEnable(enabledFlag);
+
+            // Assert
+            const string UNEXPECTED_STATE = "Unexpected {0} enabled state.";
+
+            Assert.AreEqual(enabledFlag, options.IsTypeConversionEnabled, UNEXPECTED_STATE, "ConversionType");
+            Assert.AreEqual(enabledFlag, options.IsValueConversionEnabled, UNEXPECTED_STATE, "ConversionValue");
+        }
+
+        [TestMethod]
+        #region Test data
+        [DataRow(false, false, DisplayName = "Both disabled")]
+        [DataRow(false, true, DisplayName = "Type enabled only")]
+        [DataRow(true, false, DisplayName = "Value enabled only")]
+        [DataRow(true, true, DisplayName = "Both enabled")]
+        #endregion
+        public void OptionsEnabledIndividualyTest(bool typeEnabledFlag, bool valueEnabledFlag)
+        {
+            // Arrange
+
+            // Act
+            var options =
+                new Options()
+                    .ConversionsEnable(typeEnabledFlag, valueEnabledFlag);
+
+            // Assert
+            const string UNEXPECTED_STATE = "Unexpected {0} enabled state.";
+
+            Assert.AreEqual(typeEnabledFlag, options.IsTypeConversionEnabled, UNEXPECTED_STATE, "ConversionType");
+            Assert.AreEqual(valueEnabledFlag, options.IsValueConversionEnabled, UNEXPECTED_STATE, "ConversionValue");
+        }
+
+        [TestMethod]
+        public void OptionsPrefixesTest()
+        {
+            // Arrange
+            const string UNEXPECTED_PREFIX = "Unexpected {0} prefix.";
+
+            // Act
+            var options =
+                new Options()
+                    .SetPrefixes(conversionTypePrefix: "Foo",
+                                 conversionValuePrefix: "Bar");
+
+            // Assert
+            Assert.AreEqual("Foo", options.ConversionTypePrefix, UNEXPECTED_PREFIX, "ConversionType");
+            Assert.AreEqual("Bar", options.ConversionValuePrefix, UNEXPECTED_PREFIX, "ConversionValue");
+        }
+
+        [TestMethod]
+        public void HandlerConversionDisabledTest()
+        {
+            // Arrange
+            var text = @"
+ConversionType,OriginalType,NewType
+ConversionValue,Foo,Bar
+";
+            var options = Options.None;
+            var configHandler = new ConfigHandler(options);
+            var lines =
+                text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+            var conversionHandler = new ConversionHandler(options, configHandler, lines);
+
+            // Act
+            var convertedTypeText = conversionHandler.ConvertType("OriginalType");
+            var convertedValueText = conversionHandler.ConvertValue("Foo");
+
+            // Assert
+            Assert.AreEqual("OriginalType", convertedTypeText, "Failed to convert type.");
+            Assert.AreEqual("Foo", convertedValueText, "Failed to convert value.");
+        }
+
+        [TestMethod]
+        public void HandlerConversionEnabledTest()
+        {
+            // Arrange
+            var text = @"
+ConversionType,OriginalType,NewType
+ConversionValue,Foo,Bar
+";
+            var options =
+                new Options()
+                    .ConversionsEnable(true);
+            var configHandler = new ConfigHandler(options);
+            var lines =
+                text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+            var conversionHandler = new ConversionHandler(options, configHandler, lines);
+
+            // Act
+            var convertedTypeText = conversionHandler.ConvertType("OriginalType");
+            var convertedValueText = conversionHandler.ConvertValue("Foo");
+
+            // Assert
+            Assert.AreEqual("NewType", convertedTypeText, "Failed to convert type.");
+            Assert.AreEqual("Bar", convertedValueText, "Failed to convert value.");
+        }
+    }
+}

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterAttributeTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterAttributeTests.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static Crowswood.CsvConverter.Tests.ConverterTests.ConverterBaseTests;
-
-namespace Crowswood.CsvConverter.Tests.ConverterTests
+﻿namespace Crowswood.CsvConverter.Tests.ConverterTests
 {
     [TestClass]
     public class ConverterAttributeTests
@@ -29,7 +22,7 @@ Values,Foo,1,""Picture"",TestEnum.Data";
 
             Assert.AreEqual(1, data.First().Identity, "Incorrect value for Identity of object 1.");
             Assert.AreEqual("Picture", data.First().FullName, "Incorrect value for FullName of object 1.");
-            Assert.AreEqual(TestEnum.Data, data.First().TestEnumValue, "Incorrect value for TestEnumValue of object 1.");
+            Assert.AreEqual(ConverterBaseTests.TestEnum.Data, data.First().TestEnumValue, "Incorrect value for TestEnumValue of object 1.");
         }
 
         [TestMethod]
@@ -39,7 +32,7 @@ Values,Foo,1,""Picture"",TestEnum.Data";
             var data =
                 new List<AttrFoo>
                 {
-                    new AttrFoo { Identity = 1, FullName = "Picture", TestEnumValue = TestEnum.Data, },
+                    new AttrFoo { Identity = 1, FullName = "Picture", TestEnumValue = ConverterBaseTests.TestEnum.Data, },
                 };
 
             var converter = new Converter(Options.None);
@@ -69,7 +62,7 @@ Values,Foo,1,""Picture"",TestEnum.Data";
             public string? FullName { get; set; }
 
             [CsvConverterProperty("TestEnum")]
-            public TestEnum TestEnumValue { get; set; }
+            public ConverterBaseTests.TestEnum TestEnumValue { get; set; }
         }
 
         #endregion

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterConfigTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterConfigTests.cs
@@ -11,7 +11,7 @@
         [TestMethod]
         public void ConfigurationRubbishTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 GlobalConfig,ExampleName,ExampleValue
 TypedConfig,TypeName,ExampleName,ExampleValue2
@@ -47,7 +47,7 @@ Values,ExampleType,#,""Third name"",""A further value""
         [TestMethod]
         public void ConfigurationGlobalTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 GlobalConfig,PropertyPrefix,PP
 GlobalConfig,ValuesPrefix,VP
@@ -102,7 +102,7 @@ VP,ExampleType,#,""Third"",""Gama""
         [TestMethod]
         public void ConfigurationTypedTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 TypedConfig,ExampleType,PropertyPrefix,PP
 TypedConfig,ExampleType,ValuesPrefix,VP
@@ -158,7 +158,7 @@ VP,ExampleType,#,""Third"",""Gama""
         [TestMethod]
         public void ConfigurationGlobalOverridesDefaultTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 GlobalConfig,PropertyPrefix,PP
 GlobalConfig,ValuesPrefix,VP
@@ -196,7 +196,7 @@ Values,IgnoredType,#,""222"",""BBB""
         [TestMethod]
         public void ConfigurationTypedDoesnotOverrideDefaultTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 TypedConfig,ExampleType,PropertyPrefix,PP
 TypedConfig,ExampleType,ValuesPrefix,VP

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterConversionTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterConversionTests.cs
@@ -1,0 +1,179 @@
+﻿using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter.Tests.ConverterTests
+{
+    [TestClass]
+    public class ConverterConversionTests : ConverterBaseTests
+    {
+        [TestMethod]
+        #region Test data
+        [DataRow(true, DisplayName = "Enabled")]
+        [DataRow(false, DisplayName = "Disabled")]
+        #endregion
+        public void TypelessValueConversionTest(bool conversionEnabled)
+        {
+            // Arrange
+            var text = @"
+ConversionValue,""Bread"",""Loaf""
+
+Properties,FooBar,Id,Name
+Values,FooBar,#,""Bread""
+Values,FooBar,#,""Cake""
+";
+            var options =
+                new Options()
+                    .ForType("FooBar", "Id", "Name")
+                    .ConversionsEnable(conversionEnabled);
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize");
+
+            Assert.IsTrue(data.ContainsKey("FooBar"), "Failed to deserialize FooBar.");
+
+            const string UNEXPECTED_VALUE = "Unexpected {0} of FooBar {1}.";
+            var values = data["FooBar"].Item2.ToList();
+            Assert.AreEqual(2, values.Count(), "Unexpected number of items of FooBar.");
+            Assert.AreEqual(conversionEnabled ? "Loaf" : "Bread", values[0][1], UNEXPECTED_VALUE, "Name", 0);
+            Assert.AreEqual("Cake", values[1][1], UNEXPECTED_VALUE, "Name", 1);
+        }
+
+        [TestMethod]
+        #region Test data
+        [DataRow(true, DisplayName = "Enabled")]
+        [DataRow(false, DisplayName = "Disabled")]
+        #endregion
+        public void TypedValueConversionTest(bool conversionEnabled)
+        {
+            // Arrange
+            var text = @"
+ConversionValue,""Bread"",""Loaf""
+
+Properties,Foo,Id,Name
+Values,Foo,#,""Bread""
+Values,Foo,#,""Cake""
+";
+            var options =
+                new Options()
+                    .ForType<Foo>()
+                    .ConversionsEnable(conversionEnabled);
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize<Foo>(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize.");
+
+            const string UNEXPECTED_VALUE = "Unexpected {0} of Foo {1}.";
+            var fooData =
+                data.Cast<Foo>()
+                    .NotNull()
+                    .ToList();
+            Assert.AreEqual(2, fooData.Count(), "Unexpected number of items of Foo.");
+            Assert.AreEqual(conversionEnabled ? "Loaf" : "Bread", fooData[0].Name, UNEXPECTED_VALUE, "Name", 0);
+            Assert.AreEqual("Cake", fooData[1].Name, UNEXPECTED_VALUE, "Name", 1);
+        }
+
+        [TestMethod]
+        #region Test data
+        [DataRow(true, DisplayName = "Enabled")]
+        [DataRow(false, DisplayName = "Disabled")]
+        #endregion
+        public void TypelessTypenameConversionTest(bool conversionEnabled)
+        {
+            var text = @"
+ConversionType,""FooBar"",""FooBarBaz""
+
+Properties,FooBar,Id,Name
+Values,FooBar,#,""Bread""
+Values,FooBar,#,""Cake""
+";
+            var options =
+                new Options()
+                    .ForType("FooBar", "Id", "Name")
+                    .ConversionsEnable(conversionEnabled);
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize");
+
+            Assert.IsTrue(data.ContainsKey(conversionEnabled ? "FooBarBaz" : "FooBar"), "Failed to deserialize FooBar.");
+
+            const string UNEXPECTED_VALUE = "Unexpected {0} of FooBar {1}.";
+            var values = data[conversionEnabled ? "FooBarBaz" : "FooBar"].Item2.ToList();
+            Assert.AreEqual(2, values.Count, "Unexpected number of values.");
+            Assert.AreEqual("Bread", values[0][1], UNEXPECTED_VALUE, "Name", 0);
+            Assert.AreEqual("Cake", values[1][1], UNEXPECTED_VALUE, "Name", 1);
+        }
+
+        [TestMethod]
+        #region Test data
+        [DataRow(true, DisplayName = "Enabled")]
+        [DataRow(false, DisplayName = "Disabled")]
+        #endregion
+        public void MetadataValueConversionTest(bool conversionEnabled)
+        {
+            // Arrange
+            var text = @"
+ConversionValue,Thing,OtherThing
+ConversionValue,""Quoted"",""ConvertedQuotes""
+
+Metadata,FooBar,Thing
+Metadata,FooBar,""Thing""
+Metadata,FooBar,Quoted
+Metadata,FooBar,""Quoted""
+Properties,FooBar,Id,Value
+Values,FooBar,#,""One""
+";
+            var options =
+                new Options()
+                    .ForType("FooBar", "Id", "Value")
+                    .ForMetadata("Metadata", true, "Name")
+                    .ConversionsEnable(conversionEnabled);
+            var converter = new Converter(options);
+
+            // Act
+            var data = converter.Deserialize(text);
+
+            // Assert
+            Assert.IsNotNull(data, "Failed to deserialize data.");
+            Assert.IsNotNull(converter.Metadata, "Failed to deserialize metadata.");
+
+            Assert.IsTrue(converter.Metadata.ContainsKey("FooBar"), "Found no metadata for FooBar.");
+
+            Assert.AreEqual(4, converter.Metadata["FooBar"].Count, "Unexpected number of metadata items for FooBar.");
+
+            var foobarMetadata =
+                converter.Metadata["FooBar"]
+                    .Cast<Dictionary<string, string>>()
+                    .ToList();
+            Assert.IsNotNull(foobarMetadata, "Failed to extract metadata for FooBar.");
+
+            Assert.IsTrue(foobarMetadata.All(md => md.ContainsKey("Name")), "Missing key for Name in Foobar metadata.");
+
+            var metadataValues =
+                foobarMetadata
+                    .Select(md => md["Name"])
+                    .ToList();
+
+            const string MISSING_METADATA = "FooBar Metadata missing '{0}'.";
+            if (conversionEnabled)
+            {
+                Assert.AreEqual(2, metadataValues.Count(md => md == "OtherThing"), MISSING_METADATA, "OtherThing");
+                Assert.AreEqual(2, metadataValues.Count(md => md == "ConvertedQuotes"), MISSING_METADATA, "ConvertedQuotes");
+            }
+            else
+            {
+                Assert.AreEqual(2, metadataValues.Count(md => md == "Thing"), MISSING_METADATA, "Thing");
+                Assert.AreEqual(2, metadataValues.Count(md => md == "Quoted"), MISSING_METADATA, "Quoted");
+            }
+        }
+    }
+}

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterMetadataTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterMetadataTests.cs
@@ -60,7 +60,8 @@ Values,Foo,1,""Fred"",TestEnum.Data";
 
             var optionsWithSamePropertyAndValuesPrefixes =
                 new Options()
-                    .SetPrefixes("bad", "bad");
+                    .SetPrefixes(propertiesPrefix: "bad",
+                                 valuesPrefix: "bad");
             var optionsWithSameMetadataPrefixAsProperty =
                 new Options()
                     .ForMetadata<Metadata>(vanillaOptions.PropertyPrefix, "Name");
@@ -180,6 +181,9 @@ Values,Bar,#,""Tuesday""";
                 barEntities
                     .GroupBy(n => n.Id)
                     .Any(n => n.Count() > 1), "Found duplicate Ids for Bar entities.");
+
+            Assert.IsTrue(converter.Metadata.ContainsKey(typeof(Foo).Name), "No Foo metadata.");
+            Assert.IsTrue(converter.Metadata.ContainsKey(typeof(Bar).Name), "No Bar metadata.");
 
             var bazMetadata = new List<Baz>();
             foreach (var baz in converter.Metadata[typeof(Foo).Name].Cast<Baz>())

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTypedTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTypedTests.cs
@@ -318,7 +318,7 @@ Values,Foo,1,""Fred"",TestEnum.Entity";
         [TestMethod]
         public void TypedInsufficientValuesDeserializationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,Foo,Id,Name,TestEnum
 Values,Foo,1,""Fred""
@@ -369,7 +369,7 @@ Values,Foo,#,""Harry""";
         [TestMethod]
         public void TypedReferenceDataDeserializationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,Foo,Id,Name
 Values,Foo,#,""Fred""
@@ -419,7 +419,7 @@ Values,OtherFoo,#,#Foo(""Fred""),""Beta""
         [TestMethod]
         public void TypedSelfReferencingDataDeserializationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,OtherFoo,Id,FooId,Name
 Values,OtherFoo,#,#OtherFoo(""Beta""),""Alpha""

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTypelessTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTypelessTests.cs
@@ -70,7 +70,7 @@ Values,FooBar,#,""Bert"",99,Beta",
         [TestMethod]
         public void TypelessInsufficientVauesDeserializationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,FooBar,Id,Name,OtherValue
 Values,FooBar,1,""Fred""
@@ -124,7 +124,7 @@ Values,FooBar,#,""Bert"",99,Beta";
         [TestMethod]
         public void TypelessReferenceDataDeserializationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,FooBar,Id,Name,ReferenceDataId
 Values,FooBar,#,""Fred"",#ReferenceData(""Beta"")
@@ -177,7 +177,7 @@ Values,ReferenceData,#,""Beta""";
         [TestMethod]
         public void TypelessSelfReferencingDataDeserialisationTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,FooBar,Id,FooId,Name
 Values,FooBar,#,#FooBar(""Beta""),""Alpha""
@@ -229,7 +229,7 @@ Values,FooBar,#,#FooBar(""Alpha""),""Beta""
         [TestMethod]
         public void TypelessReferenceDataDeserializationOptionsTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 Properties,FooBar,Id,Name,RefDataId,RefMeatId,RefVegId
 Values,FooBar,#,""Fred"",#ReferenceData(""Beta""),#ReferenceMeat(""Steak""),#ReferenceVeg(""Beans"")

--- a/Crowswood.CsvConverter.Tests/OptionsTests.cs
+++ b/Crowswood.CsvConverter.Tests/OptionsTests.cs
@@ -77,7 +77,8 @@
             var options = new Options();
 
             // Act
-            options.SetPrefixes("Foo", "Bar");
+            options.SetPrefixes(propertiesPrefix: "Foo",
+                                valuesPrefix: "Bar");
             options.CommentPrefixes =
                 new[]
                 {

--- a/Crowswood.CsvConverter.Tests/UserConfigTests.cs
+++ b/Crowswood.CsvConverter.Tests/UserConfigTests.cs
@@ -8,11 +8,11 @@ namespace Crowswood.CsvConverter.Tests
         [TestMethod]
         public void DefaultConstructorTest()
         {
-            // Assign
-
+            // Arrange
+            var options = Options.None;
 
             // Act
-            var handler = new ConfigHandler();
+            var handler = new ConfigHandler(options);
 
             // Assert
             Assert.IsNotNull(handler, "Failed to create handler.");
@@ -26,7 +26,7 @@ namespace Crowswood.CsvConverter.Tests
         [TestMethod]
         public void StandardConstructorTest()
         {
-            // Assign
+            // Arrange
             var text = @"
 GlobalConfig,ExampleName,ExampleValue
 TypedConfig,TypeName,ExampleName,ExampleValue2

--- a/Crowswood.CsvConverter/Converter.cs
+++ b/Crowswood.CsvConverter/Converter.cs
@@ -1,9 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
-using Crowswood.CsvConverter.Model;
+using Crowswood.CsvConverter.Processors;
 
 [assembly: InternalsVisibleTo("Crowswood.CsvConverter.Tests")]
 
@@ -30,19 +29,15 @@ namespace Crowswood.CsvConverter
 
         private readonly Options options;
 
-        private readonly IndexHandler indexHandler = new();
-        private readonly MetadataHandler metadataHandler;
-
-        private ConfigHandler configHandler = new();
-
         #endregion
 
         #region Properties
 
         /// <summary>
-        /// Gets the metadata as a dictionary keyed by <see cref="Type"/>.
+        /// Gets the metadata as a dictionary keyed by <see cref="string"/> which contains the 
+        /// type name.
         /// </summary>
-        public Dictionary<string, List<object>> Metadata => this.metadataHandler.Metadata;
+        public Dictionary<string, List<object>> Metadata { get; } = new();
 
         #endregion
 
@@ -53,11 +48,9 @@ namespace Crowswood.CsvConverter
         /// <paramref name="options"/>.
         /// </summary>
         /// <param name="options">An <see cref="options"/> object.</param>
-        public Converter(Options? options)
+        public Converter(Options options)
         {
-            this.options = OptionsHelper.ValidateOptions(options ?? Options.None);
-
-            this.metadataHandler = new(this.options, this.indexHandler);
+            this.options = OptionsHelper.ValidateOptions(options);
         }
 
         #endregion
@@ -74,46 +67,35 @@ namespace Crowswood.CsvConverter
         public IEnumerable<TBase> Deserialize<TBase>(string text)
             where TBase : class
         {
-            if (string.IsNullOrEmpty(text))
-                throw new InvalidOperationException("Text is empty.");
+            this.Metadata.Clear();
 
+            ValidateText(text);
             var lines = SplitLines(text);
 
-            this.configHandler = new(this.options, lines);
+            var configHandler = new ConfigHandler(this.options, lines);
+            var conversionHandler = new ConversionHandler(this.options, configHandler, lines);
+            var indexHandler = new IndexHandler();
+            var metadataHandler = new MetadataHandler(this.options, conversionHandler, indexHandler);
 
             var types =
                 this.options.OptionTypes.Any()
                 ? this.options.OptionTypes.Select(optionType => optionType.Type)
-                : GetTypes<TBase>(lines);
+                : GetTypes<TBase>(configHandler, lines);
 
             if (types.Any(type => type == typeof(Type)))
                 throw new InvalidOperationException("Dynamic types included.");
 
-            this.metadataHandler.Clear();
+            var processor =
+                new DeserializationProcessor(this.options,
+                                             configHandler,
+                                             conversionHandler,
+                                             indexHandler,
+                                             metadataHandler,
+                                             lines);
+            var results = processor.Process<TBase>(types);
 
-            InitialiseIndexes(true, types.Select(type => type.Name).ToArray());
-
-            // Generate a dictionary of type-less data.
-            var typelessData =
-                types
-                    .Where(type => type.IsAssignableTo(typeof(TBase)))
-                    .ToDictionary(
-                        type => type.Name,
-                        type => ConvertTo(type, lines));
-
-            foreach(var data in typelessData.Values)
-            {
-                ConvertTo(data!, typelessData!);
-            }
-
-            // Convert the type-less data to typed entities.
-            var results =
-                typelessData
-                    .Select(kvp => new { kvp.Key, Values = kvp.Value?.Get()})
-                    .Where(n => n.Values is not null)
-                    .Select(n => ConvertTo<TBase>(n.Key, ((string[], IEnumerable<string[]>))n.Values!))
-                    .SelectMany(n => n)
-                    .ToList();
+            foreach (var item in metadataHandler.Metadata)
+                this.Metadata.Add(item.Key, item.Value);
 
             return results;
         }
@@ -130,44 +112,27 @@ namespace Crowswood.CsvConverter
         /// If there are no types defined in the options, or if non-dynamic types are included.</exception>
         public Dictionary<string, (string[], IEnumerable<string[]>)> Deserialize(string text)
         {
-            if (string.IsNullOrEmpty(text))
-                throw new InvalidOperationException("Text is empty.");
+            this.Metadata.Clear();
 
+            ValidateText(text);
             var lines = SplitLines(text);
 
-            this.configHandler = new(this.options, lines);
+            var configHandler = new ConfigHandler(this.options, lines);
+            var conversionHandler = new ConversionHandler(this.options, configHandler, lines);
+            var indexHandler = new IndexHandler();
+            var metadataHandler = new MetadataHandler(this.options, conversionHandler, indexHandler);
 
-            if (!this.options.OptionTypes.Any())
-                throw new InvalidOperationException("No types defined.");
-            if (this.options.OptionTypes.Any(ot => ot.Type != typeof(Type)))
-                throw new InvalidOperationException("Non-dynamic types included.");
+            var processor =
+                new DeserializationProcessor(this.options,
+                                             configHandler,
+                                             conversionHandler,
+                                             indexHandler,
+                                             metadataHandler,
+                                             lines);
+            var results = processor.Process();
 
-            this.metadataHandler.Clear();
-
-            InitialiseIndexes(true, this.options.OptionTypes.Select(optionType => optionType.Name).ToArray());
-
-            var dynamicTypes =
-                this.options.OptionTypes
-                    .Select(optionType => optionType as OptionDynamicType)
-                    .NotNull();
-
-            var dictionary =
-                dynamicTypes
-                    .Select(dynamicType => new { dynamicType.Name, Values = ConvertTo(dynamicType, lines), })
-                    .Where(n => n.Values is not null)
-                    .NotNull()
-                    .ToDictionary(
-                        n => n.Name,
-                        n => n.Values!);
-
-            foreach (var data in dictionary.Values)
-                if (data is not null)
-                    ConvertTo(data, dictionary);
-
-            var results =
-                dictionary.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => kvp.Value.Get());
+            foreach (var item in metadataHandler.Metadata)
+                this.Metadata.Add(item.Key, item.Value);
 
             return results;
         }
@@ -180,20 +145,14 @@ namespace Crowswood.CsvConverter
         /// <returns>A <see cref="string"/>.</returns>
         public string Serialize<TBase>(IEnumerable<TBase> values) where TBase : class
         {
-            var lines = new List<string>();
+            var configHandler = new ConfigHandler(this.options, new List<string>());
+            var conversionHandler = new ConversionHandler(this.options, configHandler, new List<string>());
+            var indexHandler = new IndexHandler();
+            var metadataHandler = new MetadataHandler(this.options, conversionHandler, indexHandler);
 
-            var types = this.options.OptionTypes.Any()
-                ? this.options.OptionTypes.Select(optionType => optionType.Type)
-                : values.Select(value => value.GetType()).Distinct();
-
-            foreach(var type in types)
-            {
-                lines.AddRange(ConvertFrom(type, values));
-                lines.Add("\r\n");
-            }
-
-            var text = string.Join("\r\n", lines);
-            return text;
+            var processor = new SerializationProcessor(this.options, metadataHandler);
+            var result = processor.Process(values.ToArray());
+            return result;
         }
 
         /// <summary>
@@ -203,445 +162,19 @@ namespace Crowswood.CsvConverter
         /// <returns>A <see cref="string"/>.</returns>
         public string Serialize(Dictionary<string, (string[], IEnumerable<string[]>)> data)
         {
-            var lines = new List<string>();
+            var configHandler = new ConfigHandler(this.options, new List<string>());
+            var conversionHandler = new ConversionHandler(this.options, configHandler, new List<string>());
+            var indexHandler = new IndexHandler();
+            var metadataHandler = new MetadataHandler(this.options, conversionHandler, indexHandler);
 
-            foreach(var kvp in data)
-            {
-                if (this.Metadata.ContainsKey(kvp.Key))
-                {
-                    lines.AddRange(
-                        this.Metadata[kvp.Key]
-                            .Select(item => new
-                            {
-                                Prefix =
-                                    this.options.OptionMetadata
-                                        .Where(optionsMetadata => optionsMetadata.Type == item.GetType())
-                                        .Select(optionsMetadata => optionsMetadata.Prefix)
-                                        .FirstOrDefault(),
-                                Item = item,
-                            })
-                            .Where(n => n.Prefix is not null)
-                            .Select(n => new
-                            {
-                                n.Prefix,
-                                Values =
-                                    n.Item.GetType().GetProperties()
-                                        .Select(property => property.GetValue(n.Item)?.ToString())
-                                        .Select(value => value is null ? string.Empty : $"\"{value}\"")
-                                        .ToArray(),
-                            })
-                            .Select(n => ConversionHelper.FormatCsvData(n.Prefix!, kvp.Key, n.Values)));
-                }
-                lines.Add(ConversionHelper.FormatCsvData(this.options.PropertyPrefix, kvp.Key, kvp.Value.Item1)); //  Serialize
-                lines.AddRange(
-                    kvp.Value.Item2
-                        .Select(items => ConversionHelper.FormatCsvData(this.options.ValuesPrefix, kvp.Key, items.Select(n => $"\"{n}\"").ToArray())));
-                lines.Add("\r\n");
-            }
-
-            var text = string.Join("\r\n", lines);
-            return text;
-        }
-
-        #endregion
-
-        #region ConvertFrom serialization routines
-
-        /// <summary>
-        /// Converts the specified <paramref name="values"/> according to the <paramref name="optionType"/>
-        /// into an <see cref="IEnumerable{T}"/> of <see cref="string"/>.
-        /// </summary>
-        /// <typeparam name="TBase">The type of object to process.</typeparam>
-        /// <param name="optionType">An <see cref="OptionType"/> that controls the conversion.</param>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> that contains the objects to process.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        /// <exception cref="ArgumentException">If <seealso cref="OptionType.Type"/> cannot be assigned to <typeparamref name="TBase"/>.</exception>
-        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
-        private IEnumerable<string> ConvertFrom<TBase>(OptionType optionType, IEnumerable<TBase> values)
-            where TBase : class =>  //  can't use a new() contraint as TBase may well be abstract
-            ConvertFrom<TBase>(optionType.Type, values);
-
-        /// <summary>
-        /// Converts the specified <paramref name="values"/> of type <paramref name="type"/> into
-        /// an <see cref="IEnumerable{T}"/> of <see cref="string"/>.
-        /// </summary>
-        /// <typeparam name="TBase">The type of object to process.</typeparam>
-        /// <param name="type">The <see cref="Type"/> of object; it must be assignable to <typeparamref name="TBase"/>.</param>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> that contains the objects to process.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        /// <exception cref="ArgumentException">If <seealso cref="OptionType.Type"/> cannot be assigned to <typeparamref name="TBase"/>.</exception>
-        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
-        /// <remarks>This routine calls its namesake by reflection.</remarks>
-        private IEnumerable<string> ConvertFrom<TBase>(Type type, IEnumerable<TBase> values)
-            where TBase : class //  can't use a new() contraint as TBase may well be abstract
-        {
-            if (!type.IsAssignableTo(typeof(TBase)))
-                throw new ArgumentException(
-                    $"Unable to assign an object of type {type.Name} to {typeof(TBase).Name}.");
-
-            var name = nameof(ConvertFrom);
-
-            var returnType = typeof(IEnumerable<>).MakeGenericType(typeof(string));
-
-            // Filter the parameters to those just of the type we're currently working with.
-            var parameters = new object[]
-                {
-                    values
-                        .Where(n => n?.GetType().Equals(type) ?? false)
-                        .ToList(),
-                    type,
-                };
-
-            // Explicitly set the types, rather than relying on the type of each parameter.
-            var types =
-                new[]
-                {
-                    typeof(IEnumerable<>).MakeGenericType(typeof(TBase)),
-                    typeof(Type),
-                };
-
-            // name is the name of the method to retrieve.
-            // type is the generic type parameter.
-            // returnType is the type of the return parameter.
-            // types are the types of the parameters the method expects.
-            var method = GetType().GetGenericMethod(name, typeof(TBase), returnType, types);
-            var result =
-                method.Invoke(this, parameters) ??
-                throw new InvalidOperationException(
-                    $"Failed to convert from type {type.Name}.");
-
-            return (IEnumerable<string>)result;
-        }
-
-        /// <summary>
-        /// Converts the specified <paramref name="values"/> into an <see cref="IEnumerable{T}"/> 
-        /// of <see cref="string"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to process.</typeparam>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/> that contains the objects to process.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        /// <remarks>This routine is called by reflection.</remarks>
-        private IEnumerable<string> ConvertFrom<T>(IEnumerable<T> values, Type type)
-            where T : class //  can't use a new() contraint as TBase may well be abstract
-        {
-            var results = new List<string>();
-
-            var properties =
-                type.GetProperties()
-                    .Where(property => property.CanRead)
-                    .Where(property => property.CanWrite)
-                    .Where(property => property.PropertyType == typeof(string) ||
-                                       property.PropertyType.IsValueType &&
-                                       property.PropertyType != typeof(DateTime))
-                    .Select(property => new
-                    {
-                        Property = property,
-                        Depth = property.DeclaringType?.GetDepth() ?? 0,
-                    })
-                    .OrderBy(n => n.Depth)
-                    .Select(n => n.Property)
-                    .ToArray();
-            var parameters =
-                properties
-                    .Select(property =>
-                        this.options.OptionMembers
-                            .Where(assignment => assignment.Property.Name == property.Name)
-                            .Select(assignment => assignment.Name)
-                            .FirstOrDefault() ??
-                        property.GetCustomAttribute<CsvConverterPropertyAttribute>()?.Name ??
-                        property.Name)
-                    .ToArray();
-
-            var typeName =
-                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-                type.Name;
-
-            results.Add(ConversionHelper.FormatCsvData(this.options.PropertyPrefix, typeName, parameters)); //  ConvertFrom
-            foreach (var value in values)
-            {
-                var asStrings = ConversionHelper.AsStrings(value, properties);
-                results.Add(ConversionHelper.FormatCsvData(this.options.ValuesPrefix, typeName, asStrings.ToArray()));
-            }
-
-            return results;
-        }
-
-        #endregion
-
-        #region ConvertTo deserialization routines
-
-        /// <summary>
-        /// Converts the specified typeless <paramref name="data"/> with a named type of 
-        /// <paramref name="typeName"/> into an <see cref="IEnumerable{T}"/> of typed objects that 
-        /// derive from <typeparamref name="TBase"/>.
-        /// </summary>
-        /// <typeparam name="TBase">The base <see cref="Type"/>.</typeparam>
-        /// <param name="typeName">A <see cref="string"/> that contains the name of the type</param>
-        /// <param name="data">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the data to convert.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/>.</returns>
-        /// <exception cref="ArgumentException">
-        /// If <paramref name="typeName"/> does not match a type from the <see cref="Assembly"/> 
-        /// that contains <typeparamref name="TBase"/>.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
-        /// <remarks>
-        /// This routine calls <seealso cref="ConvertTo{T}(string[], IEnumerable{string[]})"/> by 
-        /// reflection.
-        /// </remarks>
-        private IEnumerable<TBase> ConvertTo<TBase>(string typeName, (string[], IEnumerable<string[]>) data)
-            where TBase : class
-        {
-            var types =
-                Assembly.GetAssembly(typeof(TBase))?.GetTypes()
-                    .Where(type => type.Name == typeName)
-                    .ToList() ?? new List<Type>();
-            if (types.Count > 1)
-                throw new InvalidOperationException(
-                    $"Unable to identify exactly one type called '{typeName}' from the assembly containing '{typeof(TBase).Name}'.");
-            var type = 
-                types.FirstOrDefault() ??
-                throw new ArgumentException(
-                    $"Unable to locate {typeName} from the Assembly containing {typeof(TBase).Name}.",
-                    nameof(typeName));
-
-            var returnType = typeof(IEnumerable<>).MakeGenericType(type);
-            var methodName = nameof(ConvertTo);
-            var arguments = new object[]
-            {
-                data.Item1, // names
-                data.Item2, // values
-            };
-
-            var method = GetType().GetGenericMethod(methodName, type, returnType, arguments);
-            var result =
-                method.Invoke(this, arguments) ??
-                throw new InvalidOperationException(
-                    $"Failed to convert to type {type.Name}.");
-
-            return (IEnumerable<TBase>)result;
-        }
-
-        /// <summary>
-        /// Converts the specified typeless data that is made up from <paramref name="names"/> and 
-        /// <paramref name="values"/> into an <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The <typeparamref name="T"/> of object to convert the data into.</typeparam>
-        /// <param name="names">A <see cref="string[]"/> that contains names of the properties that the <paramref name="values"/> are to populate.</param>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the data.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>.</returns>
-        /// <remarks>
-        /// This routine is called via reflection by <seealso cref="ConvertTo{TBase}(string, (string[], IEnumerable{string[]}))"/>.
-        /// </remarks>
-        private IEnumerable<T> ConvertTo<T>(string[] names, IEnumerable<string[]> values)
-            where T : class, new()
-        {
-            var type = typeof(T);
-            var propertyAndNamePairs =
-                type.GetPropertyAndAttributePairs()
-                    .GetPropertyAndNamePairs();
-
-            this.metadataHandler.Update(type);
-
-            foreach (var value in values)
-                yield return Create<T>(propertyAndNamePairs, names, value);
-        }
-
-        /// <summary>
-        /// Converts using the specified <paramref name="optionDynamicType"/> the specified 
-        /// <paramref name="lines"/> into a typeless data object.
-        /// </summary>
-        /// <param name="optionDynamicType">A <see cref="OptionDynamicType"/> object.</param>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
-        /// <returns>A <see cref="TypelessData"/> object.</returns>
-        /// <remarks>Used when deserializing into typeless data, when no subsequent conversion will be done.</remarks>
-        private TypelessData? ConvertTo(OptionDynamicType optionDynamicType, IEnumerable<string> lines)
-        {
-            this.metadataHandler.Construct(optionDynamicType.Name, lines);
-
-            var result = ConvertTo(optionDynamicType.Name, optionDynamicType.PropertyNames, null, lines);
-
+            var processor = new SerializationProcessor(this.options, metadataHandler);
+            var result = processor.Process(data);
             return result;
-        }
-
-        /// <summary>
-        /// Converts for the specified <paramref name="type"/> the specified <paramref name="lines"/> 
-        /// into a typeless data object.
-        /// </summary>
-        /// <param name="type">A <see cref="Type"/> indicating the type associated with the typeless object.</param>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
-        /// <returns>A <see cref="TypelessData"/> object.</returns>
-        /// <remarks>Used when deserializing into typeless data before converting to typed data.</remarks>
-        private TypelessData? ConvertTo(Type type, IEnumerable<string> lines)
-        {
-            this.metadataHandler.Construct(type.Name, lines);
-
-            var typeName =
-                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-                type.Name;
-
-            var propertyAndNamePairs =
-                type.GetPropertyAndAttributePairs()
-                    .GetPropertyAndNamePairs();
-
-            var propertyNames =
-                propertyAndNamePairs
-                    .Select(pair => pair.Property.Name)
-                    .ToArray();
-
-            var result = ConvertTo(typeName, propertyNames, propertyAndNamePairs?.ToArray(), lines);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Converts for the specified <paramref name="typeName"/> using the specified <paramref name="propertyNames"/> 
-        /// and <paramref name="propertyAndNamePairs"/> the specified <paramref name="lines"/> into 
-        /// a typeless data object.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> containing the type.</param>
-        /// <param name="propertyNames">A <see cref="string[]"/> containing the names for the typeless data object.</param>
-        /// <param name="propertyAndNamePairs">A <see cref="PropertyAndNamePair[]"/> that can be null.</param>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
-        /// <returns>A <see cref="TypelessData"/> object.</returns>
-        /// <exception cref="Exception">If <paramref name="lines"/> did not contain any names for <paramref name="typeName"/>.</exception>
-        private TypelessData? ConvertTo(string typeName, string[] propertyNames, PropertyAndNamePair[]? propertyAndNamePairs, IEnumerable<string> lines)
-        {
-            var names =
-                ConversionHelper.GetNames(typeName, lines, this.configHandler.GetPropertyPrefix(typeName));
-            var values = 
-                ConversionHelper.GetValues(typeName, lines, this.configHandler.GetValuePrefix(typeName));
-
-            if (names is null && values.Any())
-                throw new Exception($"Failed to identify property names for {typeName}.");
-
-            if (names is null)
-                return null;
-
-            // Create a list of indexes to allow quick look up between the property position and
-            // the name position. The names and values share the same position, the properties
-            // positions can be different.
-            var indexes = GetIndexLookup(names.ToList(), propertyNames, propertyAndNamePairs);
-
-            // This is the object that the values will be set into.
-            TypelessData result = new(propertyNames);
-
-            var valueConverter = new ValueConverter(this.indexHandler, typeName);
-
-            // Now iterate through the values read from the CSV data, extracting each individual 
-            // value in the order of the names from the CSV and placing it in the position
-            // indicated by the properties from the options.
-            // There may be names that don't exist in the properties: they will be ignored; and 
-            // properties that don't exist in the names: they will remain as empty string.
-            foreach (var value in values)
-            {
-                // Create an array of the length of the properties; initialise it to empty string.
-                var array = new string[propertyNames.Length];
-                for (var index = 0; index < array.Length; index++)
-                    array[index] = string.Empty;
-
-                // index is the position of the name within the properties.
-                for (var index = 0; index < array.Length; index++)
-                {
-                    // Check the position of the value within the row of CSV data, it may not exist!
-                    if (indexes[index] == -1 ||
-                        indexes[index] >= value.Length)
-                    {
-                        continue;
-                    }
-
-                    var item = value[indexes[index]];
-                    var propertyType = item.Trim() == "#" ? typeof(int) : typeof(string);
-                    array[index] =
-                        valueConverter.ConvertValue(item, propertyType)?.ToString() ??
-                        string.Empty;
-                }
-
-                result.Add(array);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Update the specified <paramref name="typelessData"/> that references any of the items 
-        /// from <paramref name="data"/> with the referenced value.
-        /// </summary>
-        /// <param name="typelessData">A <see cref="TypelessData"/> object that is to be updated.</param>
-        /// <param name="data">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="TypelessData"/> keyed by <see cref="string"/> that contains the reference data.</param>
-        private void ConvertTo(TypelessData typelessData, Dictionary<string, TypelessData> data)
-        {
-            var datatypes =
-                data.Keys
-                    .Select(dataType => $"#{dataType}(")
-                    .ToArray();
-
-            foreach(var name in typelessData.Names.Get())
-                for (var index = 0; index < typelessData.Values.Count(); index++)
-                    if (TryConvertValue(typelessData[name, index], datatypes, data, out var value))
-                        typelessData[name, index] = value!;
         }
 
         #endregion
 
         #region Support routines
-
-        /// <summary>
-        /// Creates and returns a new <typeparamref name="T"/> with its properties set according 
-        /// to the specified <paramref name="propertyAndNamePairs"/>, <paramref name="names"/>
-        /// and <paramref name="values"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to create.</typeparam>
-        /// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
-        /// <param name="names">A <see cref="string"/> array containing the names of the properties.</param>
-        /// <param name="values">A <see cref="string"/> array containing the values to assign to the properties.</param>
-        /// <returns>A <typeparamref name="T"/> instance.</returns>
-        /// <exception cref="ArgumentException">If the length of the <paramref name="names"/> and <paramref name="values"/> are different.</exception>
-        /// <remarks>
-        /// The length of the <paramref name="names"/> and <paramref name="values"/> arrays must
-        /// be the same, and their order must match.
-        /// </remarks>
-        private T Create<T>(IEnumerable<PropertyAndNamePair> propertyAndNamePairs, string[] names, string[] values)
-            where T : class, new()
-        {
-            var valueConverter = new ValueConverter(this.indexHandler, typeof(T).Name);
-
-            var result = 
-                new T()
-                    .SetProperties(valueConverter,
-                                   this.options.OptionMembers,
-                                   propertyAndNamePairs,
-                                   names,
-                                   values);
-            return result;
-        }
-
-        /// <summary>
-        /// Creates and returns an index look-up for the specified <paramref name="names"/> from 
-        /// the <seealso cref="Options.OptionMembers"/>, and if not null the specified <paramref name="propertyAndNamePairs"/> 
-        /// for the specified <paramref name="propertyNames"/>.
-        /// </summary>
-        /// <param name="names">A <see cref="string[]"/> containing the names of the fields in the data.</param>
-        /// <param name="propertyNames">A <see cref="string[]"/> containing the names of the properties in the type.</param>
-        /// <param name="propertyAndNamePairs">A <see cref="PropertyAndNamePair[]"/> that can be null.</param>
-        /// <returns>A <see cref="List{T}"/> of <see cref="int"/>.</returns>
-        private List<int> GetIndexLookup(List<string> names, string[] propertyNames, PropertyAndNamePair[]? propertyAndNamePairs)=>
-            propertyNames
-                .Select(propertyName =>
-                    this.options.OptionMembers
-                        .Where(optionMember => optionMember.Property.Name == propertyName)
-                        .Select(optionMember => optionMember.Name)
-                        .FirstOrDefault() ??
-                    (propertyAndNamePairs ?? Array.Empty<PropertyAndNamePair>())
-                        .Where(pair => pair.Name == propertyName)
-                        .Select(pair => pair.Name)
-                        .FirstOrDefault() ??
-                    (propertyAndNamePairs ?? Array.Empty<PropertyAndNamePair>())
-                        .Where(pair => pair.Property.Name == propertyName)
-                        .Select(pair => pair.Name)
-                        .FirstOrDefault() ??
-                    propertyName)
-                .Select(name => names.IndexOf(name))
-                .ToList();
 
         /// <summary>
         /// Gets the types that exist in the <see cref="Assembly"/> that contains <typeparamref name="TBase"/>
@@ -650,12 +183,13 @@ namespace Crowswood.CsvConverter
         /// <typeparam name="TBase">The base type.</typeparam>
         /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Type"/>.</returns>
-        private IEnumerable<Type> GetTypes<TBase>(IEnumerable<string> lines) where TBase : class
+        private static IEnumerable<Type> GetTypes<TBase>(ConfigHandler configHandler, IEnumerable<string> lines)
+            where TBase : class
         {
             var typeNames =
-                ConversionHelper.GetTypeNames(lines,
-                                              this.configHandler.GetPropertyPrefixes(),
-                                              tn => this.configHandler.GetPropertyPrefix(tn));
+                ConverterHelper.GetTypeNames(lines,
+                                              configHandler.GetPropertyPrefixes(),
+                                              tn => configHandler.GetPropertyPrefix(tn));
             var types =
                 Assembly.GetAssembly(typeof(TBase))?.GetTypes()
                     .Select(type => new
@@ -667,19 +201,6 @@ namespace Crowswood.CsvConverter
                                 typeNames.Contains(n.Attribute?.Name))
                     .Select(n => n.Type) ?? new List<Type>();
             return types;
-        }
-
-        /// <summary>
-        /// Initialise the <seealso cref="indexHandler"/>, clearing it if <paramref name="clear"/> 
-        /// is true.
-        /// </summary>
-        /// <param name="clear">A <see cref="bool"/> true to clear existing data; false otherwise.</param>
-        /// <param name="types">A <see cref="string"/> array containing the names of the types that are to be tracked.</param>
-        private void InitialiseIndexes(bool clear, params string[] typeNames)
-        {
-            if (clear)
-                this.indexHandler.Clear();
-            this.indexHandler.Initialise(typeNames);
         }
 
         /// <summary>
@@ -695,37 +216,14 @@ namespace Crowswood.CsvConverter
                 .ToList();
 
         /// <summary>
-        /// Attempt to convert the specified <paramref name="value"/> from a reference to another 
-        /// data type to the Id of the referenced record using the specified <paramref name="datatypes"/> 
-        /// and <paramref name="data"/>; the converted value is returned in <paramref name="result"/>.
+        /// Validates that the specified <paramref name="text"/> is not empty.
         /// </summary>
-        /// <param name="value">A <see cref="string"/> that contains the original value.</param>
-        /// <param name="datatypes">A <see cref="string[]"/> that contains the names of the data types with a leading '#' and trailing '('.</param>
-        /// <param name="data">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="TypelessData"/> keyed by <see cref="string"/> that contains all the data that can be referenced.</param>
-        /// <param name="result">A <see cref="string?"/> that contains the result of the conversion; or null is none was done.</param>
-        /// <returns>True if a conversion was performed; false otherwise.</returns>
-        private bool TryConvertValue(string value, string[] datatypes, Dictionary<string, TypelessData> data, out string? result)
+        /// <param name="text">A <see cref="string"/> that contains the text to validate.</param>
+        /// <exception cref="InvalidOperationException">If the <paramref name="text"/> is not valid.</exception>
+        private static void ValidateText(string text)
         {
-            result = null;
-
-            if (value.StartsWith("#") &&
-                datatypes.Any(typeName => value.StartsWith(typeName)))
-            {
-                var position = value.IndexOf("(");
-                var dataType = value[1..position];
-                var dataValue = value[(position + 1)..^1].Trim().Trim('"');
-                var values = data[dataType];
-                var nameIndex = values.Names[this.configHandler.GetReferenceNameColumnName(dataType)];
-                var idIndex = values.Names[this.configHandler.GetReferenceIdColumnName(dataType)];
-                var referenceRow =
-                    values.Values
-                        .SingleOrDefault(row => row[nameIndex] == dataValue);
-
-                if (referenceRow is not null)
-                    result = referenceRow[idIndex];
-            }
-
-            return result is not null;
+            if (string.IsNullOrWhiteSpace(text))
+                throw new InvalidOperationException("Text is empty.");
         }
 
         #endregion

--- a/Crowswood.CsvConverter/Extensions/ReflectionExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/ReflectionExtensions.cs
@@ -185,7 +185,7 @@ namespace Crowswood.CsvConverter.Extensions
             {
                 // Get the PropertyInfo to use to set the value for the name, based on the
                 // OptionMembers and PropertyAnNamePairs.
-                var property = ConversionHelper.GetProperty(members, propertyAndNamePairs, names[index]);
+                var property = ConverterHelper.GetProperty(members, propertyAndNamePairs, names[index]);
                 properties.Add(property);
             }
 

--- a/Crowswood.CsvConverter/Handlers/ConversionHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/ConversionHandler.cs
@@ -1,0 +1,117 @@
+﻿using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Model;
+
+namespace Crowswood.CsvConverter.Handlers
+{
+    internal class ConversionHandler
+    {
+        #region Fields
+
+        private readonly Options options;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the <see cref="ConversionType"/> objects.
+        /// </summary>
+        public ConversionType[] ConversionTypes { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ConversionValue"/> objects.
+        /// </summary>
+        public ConversionValue[] ConversionValues { get; }
+
+        /// <summary>
+        /// Gets whether the conversion of types is enabled.
+        /// </summary>
+        private bool IsTypeConversionEnabled => this.options.IsTypeConversionEnabled;
+
+        /// <summary>
+        /// Gets whether the conversion of values is enabled.
+        /// </summary>
+        private bool IsValueConversionEnabled => this.options.IsValueConversionEnabled;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Create a new instance using the specified <paramref name="options"/> deriving the 
+        /// <see cref="ConversionType"/> and <see cref="ConversionValue"/> arrays from the 
+        /// specified <paramref name="configHandler"/> and <paramref name="lines"/>.
+        /// </summary>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="configHandler">A <see cref="ConfigHandler"/> instance.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> that contains the lines to parse for conversions.</param>
+        public ConversionHandler(Options options, ConfigHandler configHandler, IEnumerable<string> lines)
+            : this(options, 
+                   configHandler, 
+                   ConverterHelper.GetItems(lines,
+                                            rejoinSplitQuotes: true,
+                                            trimItems: true,
+                                            typeName: null,
+                                            configHandler.GetConversionTypePrefix(),
+                                            configHandler.GetConversionValuePrefix()))
+        { }
+
+        /// <summary>
+        /// Create a new instance using the specified <paramref name="options"/> deriving the 
+        /// <see cref="ConversionType"/> and <see cref="ConversionValue"/> arrays from the 
+        /// specified <paramref name="items"/>.
+        /// </summary>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="configHandler"></param>
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> containing the items to parse for conversions.</param>
+        private ConversionHandler(Options options, ConfigHandler configHandler, IEnumerable<string[]> items)
+            : this(options,
+                   ConversionHelper.GetConversionTypes(items, configHandler),
+                   ConversionHelper.GetConversionValues(items, configHandler))
+        { }
+
+        /// <summary>
+        /// Creata a new instance using the specified <paramref name="options"/>, 
+        /// <paramref name="conversionTypes"/> and <paramref name="conversionValues"/>.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="conversionTypes"></param>
+        /// <param name="conversionValues"></param>
+        private ConversionHandler(Options options, ConversionType[] conversionTypes, ConversionValue[] conversionValues)
+        {
+            this.options = options;
+            this.ConversionTypes = conversionTypes;
+            this.ConversionValues = conversionValues;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Converts the specified <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the typename to convert.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public string ConvertType(string typeName) =>
+            this.IsTypeConversionEnabled ?
+            this.ConversionTypes
+                .Where(ct => ct.OriginalTypeName == typeName)
+                .Select(ct => ct.ConvertedTypeName)
+                .FirstOrDefault() ?? typeName : typeName;
+
+        /// <summary>
+        /// Converts the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="string"/> containing the value to convert.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public string ConvertValue(string value) =>
+            this.IsValueConversionEnabled ?
+            this.ConversionValues
+                .Where(cv => cv.OriginalValue == value)
+                .Select(cv => cv.ConvertedValue)
+                .FirstOrDefault() ?? value : value;
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
@@ -9,20 +9,20 @@ namespace Crowswood.CsvConverter.Handlers
     {
         #region Fields
 
+        private readonly Options options;
+        private readonly ConversionHandler conversionHandler;
+        private readonly IndexHandler indexHandler;
+
         private readonly Dictionary<string, TypeDescriptionProvider> providers = new();
 
         #endregion
 
         #region Properties
 
-        private IndexHandler IndexHandler { get; }
-
-        private Options Options { get; }
-
         internal Dictionary<string, List<object>> Metadata { get; } = new();
 
         private string[] MetadataPrefixes =>
-            this.Options.OptionMetadata
+            this.options.OptionMetadata
                 .Select(metadata => metadata.Prefix)
                 .ToArray();
 
@@ -30,10 +30,11 @@ namespace Crowswood.CsvConverter.Handlers
 
         #region Constructors
 
-        public MetadataHandler(Options options, IndexHandler indexHandler)
+        public MetadataHandler(Options options, ConversionHandler conversionHandler, IndexHandler indexHandler)
         {
-            this.Options = options;
-            this.IndexHandler = indexHandler;
+            this.options = options;
+            this.conversionHandler = conversionHandler;
+            this.indexHandler = indexHandler;
         }
 
         #endregion
@@ -156,7 +157,7 @@ namespace Crowswood.CsvConverter.Handlers
         /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
         /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
         private List<object> GetMetadata(string typeName, IEnumerable<string> lines) =>
-            ConversionHelper.GetItems(lines,
+            ConverterHelper.GetItems(lines,
                                       rejoinSplitQuotes: true,
                                       trimItems: false,
                                       typeName, 
@@ -182,16 +183,16 @@ namespace Crowswood.CsvConverter.Handlers
 
             var typeName = optionMetadata.Prefix;
 
-            this.IndexHandler.Initialise(typeName);
+            this.indexHandler.Initialise(typeName);
 
-            var valueConverter = new ValueConverter(this.IndexHandler, typeName);
+            var valueConverter = new ValueConverter(this.conversionHandler, this.indexHandler, typeName);
             if (optionMetadata is OptionMetadataDictionary omd)
             {
-                var dictionaryMetadata =
-                    GetMetadataDictionary(valueConverter,
-                                          optionMetadata.PropertyNames,
-                                          propertyValues,
-                                          omd.AllowNulls);
+                var dictionaryMetadata = 
+                    MetadataHelper.GetMetadataDictionary(valueConverter,
+                                                         optionMetadata.PropertyNames,
+                                                         propertyValues,
+                                                         omd.AllowNulls);
                 return omd.AllowNulls ? (object)dictionaryMetadata : dictionaryMetadata.NotNull();
             }
 
@@ -206,39 +207,13 @@ namespace Crowswood.CsvConverter.Handlers
         }
 
         /// <summary>
-        /// Creates and returns a dictionary of values using the specified <paramref name="valueConverter"/>
-        /// for the specified <paramref name="names"/> and <paramref name="values"/> and 
-        /// <paramref name="allowNulls"/> flag.
-        /// </summary>
-        /// <param name="valueConverter">The <see cref="ValueConverter"/> to use to convert the values.</param>
-        /// <param name="names">A <see cref="string"/> array containing the names that will form the keys.</param>
-        /// <param name="values">A <see cref="string"/> array containing the values.</param>
-        /// <param name="allowNulls">A <see cref="bool"/> that if true indicates that an empty string will generate null; false to generate an empty string. An string containing empty double-quotes will always generate an empty string.</param>
-        /// <returns></returns>
-        private static Dictionary<string, string?> GetMetadataDictionary(ValueConverter valueConverter,
-                                                                         string[] names,
-                                                                         string[] values,
-                                                                         bool allowNulls) =>
-            Enumerable
-                .Range(0, Math.Min(names.Length, values.Length))
-                .ToDictionary(
-                    index => names[index],
-                    index => values[index] switch
-                    {
-                        "" => allowNulls ? null : string.Empty,
-                        "\"\"" => string.Empty,
-                        _ => valueConverter.ConvertValue(values[index], typeof(string))?.ToString() ??
-                            string.Empty,
-                    });
-
-        /// <summary>
         /// Gets the <see cref="OptionMetadata"/> that has the <seealso cref="OptionMetadata.Prefix"/> 
         /// that matches the specified <paramref name="typeName"/>.
         /// </summary>
         /// <param name="typeName">A <see cref="string"/> that contains the name of the type of the metadata.</param>
         /// <returns>An <see cref="OptionMetadata"/> object; or null if none match.</returns>
         private OptionMetadata? GetOptionMetadata(string typeName) =>
-            this.Options.OptionMetadata
+            this.options.OptionMetadata
                 .FirstOrDefault(metadata => metadata.Prefix == typeName);
 
         #endregion

--- a/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
@@ -1,0 +1,55 @@
+﻿using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.UserConfig;
+
+namespace Crowswood.CsvConverter.Helpers
+{
+    /// <summary>
+    /// Static helper class to help with <see cref="UserConfig.GlobalConfig"/> and 
+    /// <see cref="UserConfig.TypedConfig"/>.
+    /// </summary>
+    internal static class ConfigHelper
+    {
+        /// <summary>
+        /// Gets all the <see cref="GlobalConfig"/> items from the specified <paramref name="items"/>.
+        /// </summary>
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the items from which the global configuration information is to be extracted.</param>
+        /// <returns>An <see cref="GlobalConfig"/> array.</returns>
+        /// <exception cref="Exception">If there are duplicate definitions; each name must be unique.</exception>
+        public static GlobalConfig[] GetGlobalConfig(IEnumerable<string[]> items)
+        {
+            var globalConfig =
+                items
+                    .Where(items => items[0] == ConfigHandler.Configurations.GlobalConfigPrefix)
+                    .Where(items => items.Length >= 3)
+                    .Select(items => new { Name = items[1], Value = items[2], })
+                    .Select(n => new GlobalConfig(n.Name, n.Value))
+                    .ToArray();
+            // Each Name must be unique.
+            if (globalConfig.Any(n => globalConfig.Count(m => m.Name == n.Name) > 1))
+                throw new Exception("Duplicate Global Config definitions.");
+            return globalConfig;
+        }
+
+        /// <summary>
+        /// Gets all the <see cref="TypedConfig"/> items from the specified <paramref name="items"/>.
+        /// </summary>
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the items from which the typed configuration information is to be extracted.</param>
+        /// <returns>A <see cref="TypedConfig"/> array.</returns>
+        /// <exception cref="Exception">If there are duplicate definitions; each typename and name conbination must be unique.</exception>
+        public static TypedConfig[] GetTypedConfig(IEnumerable<string[]> items)
+        {
+            var typedConfig =
+                items
+                    .Where(items => items[0] == ConfigHandler.Configurations.TypedConfigPrefix)
+                    .Where(items => items.Length >= 4)
+                    .Select(items => new { TypeName = items[1], Name = items[2], Value = items[3], })
+                    .Select(n => new TypedConfig(n.TypeName, n.Name, n.Value))
+                    .ToArray();
+            // Each combinatin of TypeName and Name must be unique.
+            if (typedConfig.Any(n => typedConfig.Count(m => m.TypeName == n.TypeName && m.Name == n.Name) > 1))
+                throw new Exception("Duplicate Typed Config definitions.");
+            return typedConfig;
+        }
+
+    }
+}

--- a/Crowswood.CsvConverter/Helpers/ConversionHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConversionHelper.cs
@@ -1,235 +1,48 @@
-﻿using System.Reflection;
+﻿using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Model;
 
 namespace Crowswood.CsvConverter.Helpers
 {
+    /// <summary>
+    /// An internal class that manages the conversions that use <see cref="ConversionType"/> and 
+    /// <see cref="ConversionValue"/>.
+    /// </summary>
     internal static class ConversionHelper
     {
         /// <summary>
-        /// Converts and returns the values of the properties of the specified <paramref name="item"/> 
-        /// that are in the <paramref name="properties"/> into an <see cref="IEnumerable{T}"/> of 
-        /// <see cref="string"/>.
+        /// Gets the conversion types from the specified <paramref name="items"/> using the 
+        /// specified <paramref name="configHandler"/>.
         /// </summary>
-        /// <typeparam name="TBase">The type of item to process.</typeparam>
-        /// <param name="item">A <typeparamref name="TBase"/> object.</param>
-        /// <param name="properties">A <see cref="PropertyInfo"/> array.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        internal static IEnumerable<string> AsStrings<TBase>(TBase item, PropertyInfo[] properties)
-            where TBase : class
-        {
-            var results = new List<string>();
-
-            foreach (var property in properties)
-            {
-                var value = property.GetValue(item)?.ToString();
-                var text = GetText(property.PropertyType, value);
-                results.Add(text);
-            }
-
-            return results;
-        }
-
-        /// <summary>
-        /// Format the specified <paramref name="prefix"/>, <paramref name="typeName"/> and 
-        /// <paramref name="values"/> according to the defined CSV format.
-        /// </summary>
-        /// <param name="prefix">A <see cref="string"/> that contains the prefix to put in the first column.</param>
-        /// <param name="typeName">A <see cref="string"/> that contains the type name to put in the second column.</param>
-        /// <param name="values">A <see cref="string[]"/> that contains the values to put in the remaining columns.</param>
-        /// <returns>A <see cref="string"/> containing CSV formatted values.</returns>
-        internal static string FormatCsvData(string prefix, string typeName, string[] values) => 
-            $"{prefix},{typeName},{string.Join(",", values)}";
-
-        /// <summary>
-        /// Filters the specified <paramref name="lines"/> according to the specified <paramref name="prefixes"/> 
-        /// and optionally rejoins split quotes if <paramref name="rejoinSplitQuotes"/> is true and 
-        /// trims items if <paramref name="trimItems"/> is true.
-        /// </summary>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the lines to be filtered.</param>
-        /// <param name="rejoinSplitQuotes">True to check for split quotes and rejoin any that are found.</param>
-        /// <param name="trimItems">True to trim white space from items.</param>
-        /// <param name="typeName"></param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
-        /// <param name="prefixes">A <see cref="string[]"/> that contains the prefixes to filter by.</param>
-        internal static IEnumerable<string[]> GetItems(IEnumerable<string> lines,
-                                                       bool rejoinSplitQuotes,
-                                                       bool trimItems,
-                                                       string? typeName, 
-                                                       params string[] prefixes) =>
-            lines
-                .Where(line => prefixes.Any(prefix => line.StartsWith(prefix)))
-                .Select(line => line.Split(','))
-                .Select(items => rejoinSplitQuotes ? RejoinSplitQuotes(items) : items)
-                .Select(items => trimItems ? items.Select(item => item.Trim()).ToArray() : items)
-                .Where(items => prefixes.Any(prefix => items[0] == prefix))
-                .Where(items => typeName is null || items[1] == typeName);
-
-        /// <summary>
-        /// Gets the names for the specified <paramref name="prefixes"/> and <paramref name="typeName"/> 
-        /// from the specified <paramref name="lines"/>.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
-        /// <param name="prefixes">A <see cref="string[]"/> containing the prefixes.</param>
-        /// <returns>A <see cref="string"/> array that will be null if there are no corresponding names.</returns>
-        internal static string[]? GetNames(string typeName, IEnumerable<string> lines, params string[] prefixes) =>
-            GetItems(lines,
-                     rejoinSplitQuotes: false,
-                     trimItems: true,
-                     typeName,
-                     prefixes)
-                .Select(items => items[2..^0])
-                .FirstOrDefault();
-
-        /// <summary>
-        /// Attempts to identify and return a <see cref="PropertyInfo"/> associated with the 
-        /// specified <paramref name="name"/> using the specified <paramref name="members"/> and 
-        /// <paramref name="propertyAndNamePairs"/>.
-        /// </summary>
-        /// <param name="members">An <see cref="OptionMember"/> array.</param>
-        /// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
-        /// <param name="name">A <see cref="string"/> containing the name.</param>
-        /// <returns>A <see cref="PropertyInfo"/> or null if none match.</returns>
-        /// <remarks>
-        /// Attempt to find the property in this order:
-        /// <list type="number">
-        /// <item>by option assignment; this overrides all others.</item>
-        /// <item>by defined name.</item>
-        /// <item>by property name.</item>
-        /// </list>
-        /// otherwise ignore it.
-        /// In all instances the name must match exactly, including case.
-        /// </remarks>
-        internal static PropertyInfo? GetProperty(OptionMember[] members,
-                                                  IEnumerable<PropertyAndNamePair> propertyAndNamePairs,
-                                                  string name) =>
-            members
-                .Where(member => member.Name == name)
-                .Select(member => member.Property)
-                .FirstOrDefault() ??
-            propertyAndNamePairs
-                .Where(item => item.Name == name)
-                .Select(item => item.Property)
-                .FirstOrDefault() ??
-            propertyAndNamePairs
-                .Where(item => item.Property.Name == name)
-                .Select(item => item.Property)
-                .FirstOrDefault();
-
-        /// <summary>
-        /// Gets the names of the data-types from the specified <paramref name="lines"/> using the 
-        /// specified <paramref name="prefixes"/>.
-        /// </summary>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
-        /// <param name="prefixes">A <see cref="string[]"/> of prefixes that could indicate types.</param>
-        /// <param name="getPrefix">A <see cref="Func{T, TResult}"/> that accepts a <see cref="string"/> containing the type name and returns <see cref="string"/> containing the prefix.</param>
-        /// <returns>A <see cref="string"/> array.</returns>
-        internal static string[] GetTypeNames(IEnumerable<string> lines, string[] prefixes, Func<string, string> getPrefix) =>
-            lines
-                // Include any lines that start with any of the prefixes.
-                .Where(line => prefixes.Any(prefix => line.StartsWith(prefix)))
-                .Select(line => line.Split(',', StringSplitOptions.RemoveEmptyEntries |
-                                                StringSplitOptions.TrimEntries))
-                .Where(items => items.Length >= 2)
-                .Select(items => items[0..2])
-                .Distinct()
-                // Now only include items where the prefix matches that for the typename.
-                .Where(items => items[0] == getPrefix(items[1]))
-                .Select(items => items[1])
-                .Distinct()
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that holds the text of the conversion types.</param>
+        /// <param name="configHandler">A <see cref="ConfigHandler"/> object.</param>
+        /// <returns>A <see cref="ConversionType"/> array.</returns>
+        public static ConversionType[] GetConversionTypes(IEnumerable<string[]> items,
+                                                          ConfigHandler configHandler) =>
+            items
+                .Where(items => items[0] == configHandler.GetConversionTypePrefix())
+                .Select(items => new ConversionType 
+                { 
+                    OriginalTypeName = items[1].Trim().Trim('"'),
+                    ConvertedTypeName = items[2].Trim().Trim('"'),
+                })
                 .ToArray();
 
         /// <summary>
-        /// Gets the values for the specified <paramref name="prefixes"/> and <paramref name="typeName"/> 
-        /// from the specified <paramref name="lines"/>.
+        /// Gets the conversion values from the specified <paramref name="items"/> using the 
+        /// specified <paramref name="configHandler"/>.
         /// </summary>
-        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
-        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
-        /// <param name="prefixes">A <see cref="string[]"/> containing the prefixes.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
-        internal static IEnumerable<string[]> GetValues(string typeName, IEnumerable<string> lines, params string[] prefixes) =>
-            GetItems(lines,
-                     rejoinSplitQuotes: true,
-                     trimItems: true,
-                     typeName,
-                     prefixes)
-                .Select(items => items[2..^0]);
-
-        /// <summary>
-        /// Recombines adjacent elements where a quote delimited string has been split on a comma.
-        /// </summary>
-        /// <param name="elements">A <see cref="string"/> array containing the elements to check.</param>
-        /// <returns>A <see cref="string"/> array.</returns>
-        internal static string[] RejoinSplitQuotes(string[] elements)
-        {
-            // Use a list as it's easier to remove elements.
-            var list = new List<string>(elements);
-
-            // Start the index at one, check the previous element and if needed combine the
-            // previous and current elements. This makes the end of bounds check easier.
-            var index = 1;
-            while (index < list.Count)
-            {
-                // We need to trim the elements before testing for leading / trailing double-quotes
-                // as they still retain any leading or trailing spaces at this point. This is
-                // important as there may be spaces that must be retained within the quoted text.
-                // For example, "There is a comma, contained in here" would be split into two (the
-                // square brackets [] are used to delimit the text for easy reading):
-                //  ["There is a comma]
-                //  [ contained in here"]
-                // If the leading space were trimmed from the second part then they would be
-                // recombined thus: "There is a comma,contained in here"; note the missing space.
-                if (list[index - 1].Trim().StartsWith('"') &&
-                    !list[index - 1].Trim().EndsWith('"'))
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that holds the text of the conversion values.</param>
+        /// <param name="configHandler">A <see cref="ConfigHandler"/> object.</param>
+        /// <returns>A <see cref="ConversionValue"/> array.</returns>
+        public static ConversionValue[] GetConversionValues(IEnumerable<string[]> items,
+                                                            ConfigHandler configHandler) =>
+            items
+                .Where(items => items[0] == configHandler.GetConversionValuePrefix())
+                .Select(items => new ConversionValue
                 {
-                    list[index - 1] = $"{list[index - 1]},{list[index]}";
-                    list.RemoveAt(index);
-                }
-                else
-                    // Only increment the index if the original element didn't fail the check.
-                    // Otherwise re-check it after it's been recombined with the following index.
-                    index++;
-            }
-
-            // If the number of elements hasn't changed then return the original array.
-            return elements.Length == list.Count ? elements : list.ToArray();
-        }
-
-        #region Support routines
-
-        /// <summary>
-        /// Returns a <see cref="string"/> containing the textual representation of the specified
-        /// <paramref name="value"/> according to the specified <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The <see cref="Type"/> of the value.</param>
-        /// <param name="value">A <see cref="string"/> containing the raw value.</param>
-        /// <returns>A <see cref="string"/>.</returns>
-        /// <remarks>
-        /// <seealso cref="ConvertValue(string, string, Type)"/> does the reverse.
-        /// </remarks>
-        private static string GetText(Type type, string? value)
-        {
-            if (type == typeof(string))
-                return $"\"{value ?? string.Empty}\"";
-
-            if (type == typeof(bool))
-                return value ?? false.ToString();
-
-            if (type.IsEnum)
-                // value is null or empty return empty
-                // value is not defined for enum return empty
-                // return name, if null return empty.
-                return
-                    string.IsNullOrEmpty(value) ? string.Empty :
-                    !Enum.IsDefined(type, value) ? string.Empty :
-                    $"{type.Name}.{value}";
-
-            if (type.IsValueType)
-                return value ?? 0.ToString();
-
-            return string.Empty;
-        }
-
-        #endregion
+                    OriginalValue = items[1].Trim().Trim('"'),
+                    ConvertedValue = items[2].Trim().Trim('"'),
+                })
+                .ToArray();
     }
 }

--- a/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
@@ -1,0 +1,238 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Model;
+
+namespace Crowswood.CsvConverter.Helpers
+{
+    /// <summary>
+    /// Static helper class to help with <see cref="Converter"/> functionality.
+    /// </summary>
+    internal static class ConverterHelper
+    {
+        /// <summary>
+        /// Converts and returns the values of the properties of the specified <paramref name="item"/> 
+        /// that are in the <paramref name="properties"/> into an <see cref="IEnumerable{T}"/> of 
+        /// <see cref="string"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The type of item to process.</typeparam>
+        /// <param name="item">A <typeparamref name="TBase"/> object.</param>
+        /// <param name="properties">A <see cref="PropertyInfo"/> array.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
+        internal static IEnumerable<string> AsStrings<TBase>(TBase item, PropertyInfo[] properties)
+            where TBase : class
+        {
+            var results = new List<string>();
+
+            foreach (var property in properties)
+            {
+                var value = property.GetValue(item)?.ToString();
+                var text = GetText(property.PropertyType, value);
+                results.Add(text);
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Format the specified <paramref name="prefix"/>, <paramref name="typeName"/> and 
+        /// <paramref name="values"/> according to the defined CSV format.
+        /// </summary>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix to put in the first column.</param>
+        /// <param name="typeName">A <see cref="string"/> that contains the type name to put in the second column.</param>
+        /// <param name="values">A <see cref="string[]"/> that contains the values to put in the remaining columns.</param>
+        /// <returns>A <see cref="string"/> containing CSV formatted values.</returns>
+        internal static string FormatCsvData(string prefix, string typeName, string[] values) => 
+            $"{prefix},{typeName},{string.Join(",", values)}";
+
+        /// <summary>
+        /// Filters the specified <paramref name="lines"/> according to the specified <paramref name="prefixes"/> 
+        /// and optionally rejoins split quotes if <paramref name="rejoinSplitQuotes"/> is true and 
+        /// trims items if <paramref name="trimItems"/> is true.
+        /// </summary>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the lines to be filtered.</param>
+        /// <param name="rejoinSplitQuotes">True to check for split quotes and rejoin any that are found.</param>
+        /// <param name="trimItems">True to trim white space from items.</param>
+        /// <param name="typeName"></param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
+        /// <param name="prefixes">A <see cref="string[]"/> that contains the prefixes to filter by.</param>
+        internal static IEnumerable<string[]> GetItems(IEnumerable<string> lines,
+                                                       bool rejoinSplitQuotes,
+                                                       bool trimItems,
+                                                       string? typeName, 
+                                                       params string[] prefixes) =>
+            lines
+                .Where(line => prefixes.Any(prefix => line.StartsWith(prefix)))
+                .Select(line => line.Split(','))
+                .Select(items => rejoinSplitQuotes ? RejoinSplitQuotes(items) : items)
+                .Select(items => trimItems ? items.Select(item => item.Trim()).ToArray() : items)
+                .Where(items => prefixes.Any(prefix => items[0] == prefix))
+                .Where(items => typeName is null || items[1] == typeName);
+
+        /// <summary>
+        /// Gets the names for the specified <paramref name="prefixes"/> and <paramref name="typeName"/> 
+        /// from the specified <paramref name="lines"/>.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
+        /// <param name="prefixes">A <see cref="string[]"/> containing the prefixes.</param>
+        /// <returns>A <see cref="string"/> array that will be null if there are no corresponding names.</returns>
+        internal static string[]? GetNames(string typeName, IEnumerable<string> lines, params string[] prefixes) =>
+            GetItems(lines,
+                     rejoinSplitQuotes: false,
+                     trimItems: true,
+                     typeName,
+                     prefixes)
+                .Select(items => items[2..^0])
+                .FirstOrDefault();
+
+        /// <summary>
+        /// Attempts to identify and return a <see cref="PropertyInfo"/> associated with the 
+        /// specified <paramref name="name"/> using the specified <paramref name="members"/> and 
+        /// <paramref name="propertyAndNamePairs"/>.
+        /// </summary>
+        /// <param name="members">An <see cref="OptionMember"/> array.</param>
+        /// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
+        /// <param name="name">A <see cref="string"/> containing the name.</param>
+        /// <returns>A <see cref="PropertyInfo"/> or null if none match.</returns>
+        /// <remarks>
+        /// Attempt to find the property in this order:
+        /// <list type="number">
+        /// <item>by option assignment; this overrides all others.</item>
+        /// <item>by defined name.</item>
+        /// <item>by property name.</item>
+        /// </list>
+        /// otherwise ignore it.
+        /// In all instances the name must match exactly, including case.
+        /// </remarks>
+        internal static PropertyInfo? GetProperty(OptionMember[] members,
+                                                  IEnumerable<PropertyAndNamePair> propertyAndNamePairs,
+                                                  string name) =>
+            members
+                .Where(member => member.Name == name)
+                .Select(member => member.Property)
+                .FirstOrDefault() ??
+            propertyAndNamePairs
+                .Where(item => item.Name == name)
+                .Select(item => item.Property)
+                .FirstOrDefault() ??
+            propertyAndNamePairs
+                .Where(item => item.Property.Name == name)
+                .Select(item => item.Property)
+                .FirstOrDefault();
+
+        /// <summary>
+        /// Gets the names of the data-types from the specified <paramref name="lines"/> using the 
+        /// specified <paramref name="prefixes"/>.
+        /// </summary>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
+        /// <param name="prefixes">A <see cref="string[]"/> of prefixes that could indicate types.</param>
+        /// <param name="getPrefix">A <see cref="Func{T, TResult}"/> that accepts a <see cref="string"/> containing the type name and returns <see cref="string"/> containing the prefix.</param>
+        /// <returns>A <see cref="string"/> array.</returns>
+        internal static string[] GetTypeNames(IEnumerable<string> lines, string[] prefixes, Func<string, string> getPrefix) =>
+            lines
+                // Include any lines that start with any of the prefixes.
+                .Where(line => prefixes.Any(prefix => line.StartsWith(prefix)))
+                .Select(line => line.Split(',', StringSplitOptions.RemoveEmptyEntries |
+                                                StringSplitOptions.TrimEntries))
+                .Where(items => items.Length >= 2)
+                .Select(items => items[0..2])
+                .Distinct()
+                // Now only include items where the prefix matches that for the typename.
+                .Where(items => items[0] == getPrefix(items[1]))
+                .Select(items => items[1])
+                .Distinct()
+                .ToArray();
+
+        /// <summary>
+        /// Gets the values for the specified <paramref name="prefixes"/> and <paramref name="typeName"/> 
+        /// from the specified <paramref name="lines"/>.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</param>
+        /// <param name="prefixes">A <see cref="string[]"/> containing the prefixes.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
+        internal static IEnumerable<string[]> GetValues(string typeName, IEnumerable<string> lines, params string[] prefixes) =>
+            GetItems(lines,
+                     rejoinSplitQuotes: true,
+                     trimItems: true,
+                     typeName,
+                     prefixes)
+                .Select(items => items[2..^0]);
+
+        /// <summary>
+        /// Recombines adjacent elements where a quote delimited string has been split on a comma.
+        /// </summary>
+        /// <param name="elements">A <see cref="string"/> array containing the elements to check.</param>
+        /// <returns>A <see cref="string"/> array.</returns>
+        internal static string[] RejoinSplitQuotes(string[] elements)
+        {
+            // Use a list as it's easier to remove elements.
+            var list = new List<string>(elements);
+
+            // Start the index at one, check the previous element and if needed combine the
+            // previous and current elements. This makes the end of bounds check easier.
+            var index = 1;
+            while (index < list.Count)
+            {
+                // We need to trim the elements before testing for leading / trailing double-quotes
+                // as they still retain any leading or trailing spaces at this point. This is
+                // important as there may be spaces that must be retained within the quoted text.
+                // For example, "There is a comma, contained in here" would be split into two (the
+                // square brackets [] are used to delimit the text for easy reading):
+                //  ["There is a comma]
+                //  [ contained in here"]
+                // If the leading space were trimmed from the second part then they would be
+                // recombined thus: "There is a comma,contained in here"; note the missing space.
+                if (list[index - 1].Trim().StartsWith('"') &&
+                    !list[index - 1].Trim().EndsWith('"'))
+                {
+                    list[index - 1] = $"{list[index - 1]},{list[index]}";
+                    list.RemoveAt(index);
+                }
+                else
+                    // Only increment the index if the original element didn't fail the check.
+                    // Otherwise re-check it after it's been recombined with the following index.
+                    index++;
+            }
+
+            // If the number of elements hasn't changed then return the original array.
+            return elements.Length == list.Count ? elements : list.ToArray();
+        }
+
+        #region Support routines
+
+        /// <summary>
+        /// Returns a <see cref="string"/> containing the textual representation of the specified
+        /// <paramref name="value"/> according to the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> of the value.</param>
+        /// <param name="value">A <see cref="string"/> containing the raw value.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        /// <remarks>
+        /// <seealso cref="ConvertValue(string, string, Type)"/> does the reverse.
+        /// </remarks>
+        private static string GetText(Type type, string? value)
+        {
+            if (type == typeof(string))
+                return $"\"{value ?? string.Empty}\"";
+
+            if (type == typeof(bool))
+                return value ?? false.ToString();
+
+            if (type.IsEnum)
+                // value is null or empty return empty
+                // value is not defined for enum return empty
+                // return name, if null return empty.
+                return
+                    string.IsNullOrEmpty(value) ? string.Empty :
+                    !Enum.IsDefined(type, value) ? string.Empty :
+                    $"{type.Name}.{value}";
+
+            if (type.IsValueType)
+                return value ?? 0.ToString();
+
+            return string.Empty;
+        }
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter/Helpers/MetadataHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/MetadataHelper.cs
@@ -1,0 +1,35 @@
+﻿namespace Crowswood.CsvConverter.Helpers
+{
+    /// <summary>
+    /// Static helper class to help with metadata.
+    /// </summary>
+    internal static class MetadataHelper
+    {
+
+        /// <summary>
+        /// Creates and returns a dictionary of values using the specified <paramref name="valueConverter"/>
+        /// for the specified <paramref name="names"/> and <paramref name="values"/> and 
+        /// <paramref name="allowNulls"/> flag.
+        /// </summary>
+        /// <param name="valueConverter">The <see cref="ValueConverter"/> to use to convert the values.</param>
+        /// <param name="names">A <see cref="string"/> array containing the names that will form the keys.</param>
+        /// <param name="values">A <see cref="string"/> array containing the values.</param>
+        /// <param name="allowNulls">A <see cref="bool"/> that if true indicates that an empty string will generate null; false to generate an empty string. An string containing empty double-quotes will always generate an empty string.</param>
+        /// <returns></returns>
+        public static Dictionary<string, string?> GetMetadataDictionary(ValueConverter valueConverter,
+                                                                         string[] names,
+                                                                         string[] values,
+                                                                         bool allowNulls) =>
+            Enumerable
+                .Range(0, Math.Min(names.Length, values.Length))
+                .ToDictionary(
+                    index => names[index],
+                    index => values[index] switch
+                    {
+                        "" => allowNulls ? null : string.Empty,
+                        "\"\"" => string.Empty,
+                        _ => valueConverter.ConvertValue(values[index], typeof(string))?.ToString() ??
+                            string.Empty,
+                    });
+    }
+}

--- a/Crowswood.CsvConverter/Model/ConversionType.cs
+++ b/Crowswood.CsvConverter/Model/ConversionType.cs
@@ -1,0 +1,18 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    /// <summary>
+    /// A model class to hold type name conversion data.
+    /// </summary>
+    internal class ConversionType
+    {
+        /// <summary>
+        /// Gets and initialises the original value, which will be converted from.
+        /// </summary>
+        public string? OriginalTypeName { get; init; }
+
+        /// <summary>
+        /// Gets and initialises the converted value.
+        /// </summary>
+        public string? ConvertedTypeName { get; init; }
+    }
+}

--- a/Crowswood.CsvConverter/Model/ConversionValue.cs
+++ b/Crowswood.CsvConverter/Model/ConversionValue.cs
@@ -1,0 +1,18 @@
+﻿namespace Crowswood.CsvConverter.Model
+{
+    /// <summary>
+    /// A model class to hold value conversion data.
+    /// </summary>
+    internal class ConversionValue
+    {
+        /// <summary>
+        /// Gets and initialises the original value, which will be converted from.
+        /// </summary>
+        public string? OriginalValue { get; init; }
+
+        /// <summary>
+        /// Gets and initialises the converted value.
+        /// </summary>
+        public string? ConvertedValue { get; init; }
+    }
+}

--- a/Crowswood.CsvConverter/Model/Typeless.cs
+++ b/Crowswood.CsvConverter/Model/Typeless.cs
@@ -6,6 +6,10 @@
 
     internal abstract class Typeless<T> : Typeless
     {
+        /// <summary>
+        /// Gets the underlying value of the current instance.
+        /// </summary>
+        /// <returns>A <typeparamref name="T"/> instance.</returns>
         public abstract T Get();
     }
 }

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -69,6 +69,26 @@ namespace Crowswood.CsvConverter
         /// </summary>
         public string ValuesPrefix { get; private set; } = "Values";
 
+        /// <summary>
+        /// Gets the <see cref="string"/> that contains the conversion type prefix.
+        /// </summary>
+        public string ConversionTypePrefix { get; private set; } = "ConversionType";
+
+        /// <summary>
+        /// Gets the <see cref="string"/> that contains the conversion value prefix.
+        /// </summary>
+        public string ConversionValuePrefix { get; private set; } = "ConversionValue";
+
+        /// <summary>
+        /// Gets whether the conversion of types is enabled.
+        /// </summary>
+        public bool IsTypeConversionEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets whether the conversion of values is enabled.
+        /// </summary>
+        public bool IsValueConversionEnabled { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -87,6 +107,27 @@ namespace Crowswood.CsvConverter
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Enable and disable the conversion of types and values.
+        /// </summary>
+        /// <param name="enable">True to enable conversions; false otherwise.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ConversionsEnable(bool enable) => ConversionsEnable(enable, enable);
+
+        /// <summary>
+        /// Enable and disable the conversion of types and values independently.
+        /// </summary>
+        /// <param name="enableTypeConversions">True to enable type conversions; false otherwise.</param>
+        /// <param name="enableValueConversions">True to enable value conversions; false otherwise.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        public Options ConversionsEnable(bool enableTypeConversions, bool enableValueConversions)
+        {
+            this.IsTypeConversionEnabled = enableTypeConversions;
+            this.IsValueConversionEnabled = enableValueConversions;
+
+            return this;
+        }
 
         /// <summary>
         /// Adds the specified <paramref name="optionMember"/>.
@@ -201,12 +242,24 @@ namespace Crowswood.CsvConverter
         /// <param name="propertiesPrefix">A <see cref="string"/> containing the new properties prefix value or null for no change.</param>
         /// <param name="valuesPrefix">A <see cref="string"/> containing the new values prefix value or null for no change.</param>
         /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
-        public Options SetPrefixes(string? propertiesPrefix, string? valuesPrefix)
+        public Options SetPrefixes(string? propertiesPrefix = null,
+                                   string? valuesPrefix = null,
+                                   string? conversionTypePrefix = null,
+                                   string? conversionValuePrefix = null)
         {
+
+            if (this.none)
+                return this;
+
             if (!string.IsNullOrWhiteSpace(propertiesPrefix))
                 this.PropertyPrefix = propertiesPrefix;
             if (!string.IsNullOrWhiteSpace(valuesPrefix))
                 this.ValuesPrefix = valuesPrefix;
+            if (!string.IsNullOrWhiteSpace(conversionTypePrefix))
+                this.ConversionTypePrefix = conversionTypePrefix;
+            if (!string.IsNullOrWhiteSpace(conversionValuePrefix))
+                this.ConversionValuePrefix = conversionValuePrefix;
+
             return this;
         }
 

--- a/Crowswood.CsvConverter/Processors/DeserializationProcessor.cs
+++ b/Crowswood.CsvConverter/Processors/DeserializationProcessor.cs
@@ -1,0 +1,448 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Model;
+
+namespace Crowswood.CsvConverter.Processors
+{
+    internal class DeserializationProcessor
+    {
+        #region Fields
+
+        private readonly Options options;
+
+        private readonly ConfigHandler configHandler;
+        private readonly ConversionHandler conversionHandler;
+        private readonly IndexHandler indexHandler;
+        private readonly MetadataHandler metadataHandler;
+
+        private readonly IEnumerable<string> lines;
+
+        #endregion
+
+        #region Constructors
+
+        public DeserializationProcessor(Options options,
+                                        ConfigHandler configHandler,
+                                        ConversionHandler conversionHandler,
+                                        IndexHandler indexHandler,
+                                        MetadataHandler metadataHandler,
+                                        IEnumerable<string> lines)
+        {
+            this.options = options;
+
+            this.configHandler = configHandler;
+            this.conversionHandler = conversionHandler;
+            this.indexHandler = indexHandler;
+            this.metadataHandler = metadataHandler;
+
+            this.lines = lines;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Deserialize text into an <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> 
+        /// objects.
+        /// </summary>
+        /// <typeparam name="TBase">The base type of objects to return.</typeparam>
+        /// <param name="types">An <see cref="IEnumerable{T}"/> of <see cref="Type"/> that contains the types to process.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/>.</returns>
+        internal IEnumerable<TBase> Process<TBase>(IEnumerable<Type> types) 
+            where TBase : class
+        {
+            InitialiseIndexes(true, types.Select(type => type.Name).ToArray());
+
+            // Generate a dictionary of type-less data.
+            var typelessData =
+                types
+                    .Where(type => type.IsAssignableTo(typeof(TBase)))
+                    .ToDictionary(
+                        type => this.conversionHandler.ConvertType(type.Name),
+                        type => ConvertTo(type, lines));
+
+            foreach (var data in typelessData.Values)
+                ConvertTo(data!, typelessData!);
+
+            // Convert the type-less data to typed entities.
+            var results =
+                typelessData
+                    .Select(kvp => new { kvp.Key, Values = kvp.Value?.Get() })
+                    .Where(n => n.Values is not null)
+                    .Select(n => ConvertTo<TBase>(n.Key, ((string[], IEnumerable<string[]>))n.Values!))
+                    .SelectMany(n => n)
+                    .ToList();
+
+            return results;
+        }
+
+        /// <summary>
+        /// Deserialize text into a <see cref="Dictionary{TKey, TValue}"/> of <see cref="Tuple{T1, T2}"/> 
+        /// of <see cref="string[]"/> and <see cref="IEnumerable{T}"/> of <see cref="string[]"/>, 
+        /// keyed by <see cref="string"/>.
+        /// </summary>
+        /// <returns>A  <see cref="Dictionary{TKey, TValue}"/> of <see cref="Tuple{T1, T2}"/> of <see cref="string[]"/> and <see cref="IEnumerable{T}"/> of <see cref="string[]"/>, keyed by <see cref="string"/>.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// If there are no types defined in the options, or if non-dynamic types are included.
+        /// </exception>
+        internal Dictionary<string, (string[], IEnumerable<string[]>)> Process()
+        {
+            InitialiseIndexes(true, this.options.OptionTypes.Select(optionType => optionType.Name).ToArray());
+
+            var dynamicTypes =
+                this.options.OptionTypes
+                    .Select(optionType => optionType as OptionDynamicType)
+                    .NotNull();
+
+            var dictionary =
+                dynamicTypes
+                    .Select(dynamicType => new
+                    {
+                        Name = this.conversionHandler.ConvertType(dynamicType.Name),
+                        Values = ConvertTo(dynamicType, lines),
+                    })
+                    .Where(n => n.Values is not null)
+                    .ToDictionary(n => n.Name, n => n.Values!);
+
+            foreach (var data in dictionary.Values)
+                if (data is not null)
+                    ConvertTo(data, dictionary);
+
+            var results =
+                dictionary.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.Get());
+
+            return results;
+        }
+
+        #endregion
+
+        #region Conversion routines
+
+        /// <summary>
+        /// Converts the specified typeless <paramref name="data"/> with a named type of 
+        /// <paramref name="typeName"/> into an <see cref="IEnumerable{T}"/> of typed objects that 
+        /// derive from <typeparamref name="TBase"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The base <see cref="Type"/>.</typeparam>
+        /// <param name="typeName">A <see cref="string"/> that contains the name of the type</param>
+        /// <param name="data">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the data to convert.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/>.</returns>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="typeName"/> does not match a type from the <see cref="Assembly"/> 
+        /// that contains <typeparamref name="TBase"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
+        /// <remarks>
+        /// This routine calls <seealso cref="ConvertTo{T}(string[], IEnumerable{string[]})"/> by 
+        /// reflection.
+        /// </remarks>
+        private IEnumerable<TBase> ConvertTo<TBase>(string typeName, (string[], IEnumerable<string[]>) data)
+            where TBase : class
+        {
+            var types =
+                Assembly.GetAssembly(typeof(TBase))?.GetTypes()
+                    .Where(type => type.Name == typeName)
+                    .ToList() ?? new List<Type>();
+            if (types.Count > 1)
+                throw new InvalidOperationException(
+                    $"Unable to identify exactly one type called '{typeName}' from the assembly containing '{typeof(TBase).Name}'.");
+            var type =
+                types.FirstOrDefault() ??
+                throw new ArgumentException(
+                    $"Unable to locate {typeName} from the Assembly containing {typeof(TBase).Name}.",
+                    nameof(typeName));
+
+            var returnType = typeof(IEnumerable<>).MakeGenericType(type);
+            var methodName = nameof(ConvertTo);
+            var arguments = new object[]
+            {
+                data.Item1, // names
+                data.Item2, // values
+            };
+
+            var method = GetType().GetGenericMethod(methodName, type, returnType, arguments);
+            var result =
+                method.Invoke(this, arguments) ??
+                throw new InvalidOperationException(
+                    $"Failed to convert to type {type.Name}.");
+
+            return (IEnumerable<TBase>)result;
+        }
+
+        /// <summary>
+        /// Converts the specified typeless data that is made up from <paramref name="names"/> and 
+        /// <paramref name="values"/> into an <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The <typeparamref name="T"/> of object to convert the data into.</typeparam>
+        /// <param name="names">A <see cref="string[]"/> that contains names of the properties that the <paramref name="values"/> are to populate.</param>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> that contains the data.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// This routine is called via reflection by <seealso cref="ConvertTo{TBase}(string, (string[], IEnumerable{string[]}))"/>.
+        /// </remarks>
+        private IEnumerable<T> ConvertTo<T>(string[] names, IEnumerable<string[]> values)
+            where T : class, new()
+        {
+            var type = typeof(T);
+            var propertyAndNamePairs =
+                type.GetPropertyAndAttributePairs()
+                    .GetPropertyAndNamePairs();
+
+            this.metadataHandler.Update(type);
+
+            foreach (var value in values)
+                yield return Create<T>(propertyAndNamePairs, names, value);
+        }
+
+        /// <summary>
+        /// Converts using the specified <paramref name="optionDynamicType"/> the specified 
+        /// <paramref name="lines"/> into a typeless data object.
+        /// </summary>
+        /// <param name="optionDynamicType">A <see cref="OptionDynamicType"/> object.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
+        /// <returns>A <see cref="TypelessData"/> object.</returns>
+        /// <remarks>Used when deserializing into typeless data, when no subsequent conversion will be done.</remarks>
+        private TypelessData? ConvertTo(OptionDynamicType optionDynamicType, IEnumerable<string> lines)
+        {
+            this.metadataHandler.Construct(optionDynamicType.Name, lines);
+
+            var result = ConvertTo(optionDynamicType.Name, optionDynamicType.PropertyNames, null, lines);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts for the specified <paramref name="type"/> the specified <paramref name="lines"/> 
+        /// into a typeless data object.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/> indicating the type associated with the typeless object.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
+        /// <returns>A <see cref="TypelessData"/> object.</returns>
+        /// <remarks>Used when deserializing into typeless data before converting to typed data.</remarks>
+        private TypelessData? ConvertTo(Type type, IEnumerable<string> lines)
+        {
+            var typeName =
+                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+                type.Name;
+
+            var propertyAndNamePairs =
+                type.GetPropertyAndAttributePairs()
+                    .GetPropertyAndNamePairs();
+
+            var propertyNames =
+                propertyAndNamePairs
+                    .Select(pair => pair.Property.Name)
+                    .ToArray();
+
+            this.metadataHandler.Construct(typeName, lines);
+
+            var result = ConvertTo(typeName, propertyNames, propertyAndNamePairs?.ToArray(), lines);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts for the specified <paramref name="typeName"/> using the specified <paramref name="propertyNames"/> 
+        /// and <paramref name="propertyAndNamePairs"/> the specified <paramref name="lines"/> into 
+        /// a typeless data object.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the type.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the names for the typeless data object.</param>
+        /// <param name="propertyAndNamePairs">A <see cref="PropertyAndNamePair[]"/> that can be null.</param>
+        /// <param name="lines">An <see cref="IEnumerable{T}"/> of <see cref="string"/> containing the data to convert.</param>
+        /// <returns>A <see cref="TypelessData"/> object.</returns>
+        /// <exception cref="Exception">If <paramref name="lines"/> did not contain any names for <paramref name="typeName"/>.</exception>
+        private TypelessData? ConvertTo(string typeName, string[] propertyNames, PropertyAndNamePair[]? propertyAndNamePairs, IEnumerable<string> lines)
+        {
+            var names =
+                ConverterHelper.GetNames(typeName, lines, this.configHandler.GetPropertyPrefix(typeName));
+            var values =
+                ConverterHelper.GetValues(typeName, lines, this.configHandler.GetValuePrefix(typeName));
+
+            if (names is null && values.Any())
+                throw new Exception($"Failed to identify property names for {typeName}.");
+
+            if (names is null)
+                return null;
+
+            // Create a list of indexes to allow quick look up between the property position and
+            // the name position. The names and values share the same position, the properties
+            // positions can be different.
+            var indexes = GetIndexLookup(names.ToList(), propertyNames, propertyAndNamePairs);
+
+            // This is the object that the values will be set into.
+            TypelessData result = new(propertyNames);
+
+            var valueConverter = new ValueConverter(conversionHandler, this.indexHandler, typeName);
+
+            // Now iterate through the values read from the CSV data, extracting each individual 
+            // value in the order of the names from the CSV and placing it in the position
+            // indicated by the properties from the options.
+            // There may be names that don't exist in the properties: they will be ignored; and 
+            // properties that don't exist in the names: they will remain as empty string.
+            foreach (var value in values)
+            {
+                // Create an array of the length of the properties; initialise it to empty string.
+                var array = new string[propertyNames.Length];
+                for (var index = 0; index < array.Length; index++)
+                    array[index] = string.Empty;
+
+                // index is the position of the name within the properties.
+                for (var index = 0; index < array.Length; index++)
+                {
+                    // Check the position of the value within the row of CSV data, it may not exist!
+                    if (indexes[index] == -1 ||
+                        indexes[index] >= value.Length)
+                    {
+                        continue;
+                    }
+
+                    var item = value[indexes[index]];
+                    var propertyType = item.Trim() == "#" ? typeof(int) : typeof(string);
+                    array[index] =
+                        valueConverter.ConvertValue(item, propertyType)?.ToString() ??
+                        string.Empty;
+                }
+
+                result.Add(array);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Update the specified <paramref name="typelessData"/> that references any of the items 
+        /// from <paramref name="data"/> with the referenced value.
+        /// </summary>
+        /// <param name="typelessData">A <see cref="TypelessData"/> object that is to be updated.</param>
+        /// <param name="data">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="TypelessData"/> keyed by <see cref="string"/> that contains the reference data.</param>
+        private void ConvertTo(TypelessData typelessData, Dictionary<string, TypelessData> data)
+        {
+            var datatypes =
+                data.Keys
+                    .Select(dataType => $"#{dataType}(")
+                    .ToArray();
+
+            foreach (var name in typelessData.Names.Get())
+                for (var index = 0; index < typelessData.Values.Count(); index++)
+                    if (TryConvertValue(typelessData[name, index], datatypes, data, out var value))
+                        typelessData[name, index] = value!;
+        }
+
+        #endregion
+
+        #region Support routines
+
+        /// <summary>
+        /// Creates and returns a new <typeparamref name="T"/> with its properties set according 
+        /// to the specified <paramref name="propertyAndNamePairs"/>, <paramref name="names"/>
+        /// and <paramref name="values"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create.</typeparam>
+        /// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
+        /// <param name="names">A <see cref="string"/> array containing the names of the properties.</param>
+        /// <param name="values">A <see cref="string"/> array containing the values to assign to the properties.</param>
+        /// <returns>A <typeparamref name="T"/> instance.</returns>
+        /// <exception cref="ArgumentException">If the length of the <paramref name="names"/> and <paramref name="values"/> are different.</exception>
+        /// <remarks>
+        /// The length of the <paramref name="names"/> and <paramref name="values"/> arrays must
+        /// be the same, and their order must match.
+        /// </remarks>
+        private T Create<T>(IEnumerable<PropertyAndNamePair> propertyAndNamePairs, string[] names, string[] values)
+            where T : class, new()
+        {
+            var valueConverter = new ValueConverter(conversionHandler, this.indexHandler, typeof(T).Name);
+
+            var result =
+                new T()
+                    .SetProperties(valueConverter,
+                                   this.options.OptionMembers,
+                                   propertyAndNamePairs,
+                                   names,
+                                   values);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates and returns an index look-up for the specified <paramref name="names"/> from 
+        /// the <seealso cref="Options.OptionMembers"/>, and if not null the specified <paramref name="propertyAndNamePairs"/> 
+        /// for the specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="names">A <see cref="string[]"/> containing the names of the fields in the data.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the names of the properties in the type.</param>
+        /// <param name="propertyAndNamePairs">A <see cref="PropertyAndNamePair[]"/> that can be null.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="int"/>.</returns>
+        private List<int> GetIndexLookup(List<string> names, string[] propertyNames, PropertyAndNamePair[]? propertyAndNamePairs) =>
+            propertyNames
+                .Select(propertyName =>
+                    this.options.OptionMembers
+                        .Where(optionMember => optionMember.Property.Name == propertyName)
+                        .Select(optionMember => optionMember.Name)
+                        .FirstOrDefault() ??
+                    (propertyAndNamePairs ?? Array.Empty<PropertyAndNamePair>())
+                        .Where(pair => pair.Name == propertyName)
+                        .Select(pair => pair.Name)
+                        .FirstOrDefault() ??
+                    (propertyAndNamePairs ?? Array.Empty<PropertyAndNamePair>())
+                        .Where(pair => pair.Property.Name == propertyName)
+                        .Select(pair => pair.Name)
+                        .FirstOrDefault() ??
+                    propertyName)
+                .Select(name => names.IndexOf(name))
+                .ToList();
+
+        /// <summary>
+        /// Initialise the <seealso cref="indexHandler"/>, clearing it if <paramref name="clear"/> 
+        /// is true.
+        /// </summary>
+        /// <param name="clear">A <see cref="bool"/> true to clear existing data; false otherwise.</param>
+        /// <param name="types">A <see cref="string"/> array containing the names of the types that are to be tracked.</param>
+        private void InitialiseIndexes(bool clear, params string[] typeNames)
+        {
+            if (clear)
+                this.indexHandler.Clear();
+            this.indexHandler.Initialise(typeNames);
+        }
+
+        /// <summary>
+        /// Attempt to convert the specified <paramref name="value"/> from a reference to another 
+        /// data type to the Id of the referenced record using the specified <paramref name="datatypes"/> 
+        /// and <paramref name="data"/>; the converted value is returned in <paramref name="result"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="string"/> that contains the original value.</param>
+        /// <param name="datatypes">A <see cref="string[]"/> that contains the names of the data types with a leading '#' and trailing '('.</param>
+        /// <param name="data">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="TypelessData"/> keyed by <see cref="string"/> that contains all the data that can be referenced.</param>
+        /// <param name="result">A <see cref="string?"/> that contains the result of the conversion; or null is none was done.</param>
+        /// <returns>True if a conversion was performed; false otherwise.</returns>
+        private bool TryConvertValue(string value, string[] datatypes, Dictionary<string, TypelessData> data, out string? result)
+        {
+            result = null;
+
+            if (value.StartsWith("#") &&
+                datatypes.Any(typeName => value.StartsWith(typeName)))
+            {
+                var position = value.IndexOf("(");
+                var dataType = value[1..position];
+                var dataValue = value[(position + 1)..^1].Trim().Trim('"');
+                var values = data[dataType];
+                var nameIndex = values.Names[this.configHandler.GetReferenceNameColumnName(dataType)];
+                var idIndex = values.Names[this.configHandler.GetReferenceIdColumnName(dataType)];
+                var referenceRow =
+                    values.Values
+                        .SingleOrDefault(row => row[nameIndex] == dataValue);
+
+                if (referenceRow is not null)
+                    result = referenceRow[idIndex];
+            }
+
+            return result is not null;
+        }
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
+++ b/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
@@ -1,0 +1,227 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.Helpers;
+
+namespace Crowswood.CsvConverter.Processors
+{
+    internal class SerializationProcessor
+    {
+        #region Fields
+
+        private readonly Options options;
+
+        private readonly MetadataHandler metadataHandler;
+
+        #endregion
+
+        #region Constructors
+
+        public SerializationProcessor(Options options, MetadataHandler metadataHandler)
+        {
+            this.options = options;
+
+            this.metadataHandler = metadataHandler;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Serializes the specified <paramref name="values"/> to a <see cref="string"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The base type of objects to serialize.</typeparam>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> to serialize.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        internal string Process<T>(params T[] values) where T : class
+        {
+            var lines = new List<string>();
+
+            var types = this.options.OptionTypes.Any()
+                ? this.options.OptionTypes.Select(optionType => optionType.Type)
+                : values.Select(value => value.GetType()).Distinct();
+
+            foreach (var type in types)
+            {
+                lines.AddRange(ConvertFrom(type, values));
+                lines.Add("\r\n");
+            }
+
+            var text = string.Join("\r\n", lines);
+            return text;
+        }
+
+        /// <summary>
+        /// Serializes the specified <paramref name="data"/> to a <see cref="string"/>.
+        /// </summary>
+        /// <param name="data">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="Tuple{T1, T2}"/> of <see cref="string[]"/> and <see cref="IEnumerable{T}"/> of <see cref="string[]"/> keyed by <see cref="string"/>.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        internal string Process(Dictionary<string, (string[], IEnumerable<string[]>)> data)
+        {
+            var lines = new List<string>();
+
+            foreach (var kvp in data)
+            {
+                if (this.metadataHandler.Metadata.ContainsKey(kvp.Key))
+                {
+                    lines.AddRange(
+                        this.metadataHandler.Metadata[kvp.Key]
+                            .Select(item => new
+                            {
+                                Prefix =
+                                    this.options.OptionMetadata
+                                        .Where(optionsMetadata => optionsMetadata.Type == item.GetType())
+                                        .Select(optionsMetadata => optionsMetadata.Prefix)
+                                        .FirstOrDefault(),
+                                Item = item,
+                            })
+                            .Where(n => n.Prefix is not null)
+                            .Select(n => new
+                            {
+                                n.Prefix,
+                                Values =
+                                    n.Item.GetType().GetProperties()
+                                        .Select(property => property.GetValue(n.Item)?.ToString())
+                                        .Select(value => value is null ? string.Empty : $"\"{value}\"")
+                                        .ToArray(),
+                            })
+                            .Select(n => ConverterHelper.FormatCsvData(n.Prefix!, kvp.Key, n.Values)));
+                }
+                lines.Add(ConverterHelper.FormatCsvData(this.options.PropertyPrefix, kvp.Key, kvp.Value.Item1)); //  Serialize
+                lines.AddRange(
+                    kvp.Value.Item2
+                        .Select(items => ConverterHelper.FormatCsvData(this.options.ValuesPrefix, kvp.Key, items.Select(n => $"\"{n}\"").ToArray())));
+                lines.Add("\r\n");
+            }
+
+            var text = string.Join("\r\n", lines);
+            return text;
+        }
+
+        #endregion
+
+        #region Conversion routines
+
+        /// <summary>
+        /// Converts the specified <paramref name="values"/> according to the <paramref name="optionType"/>
+        /// into an <see cref="IEnumerable{T}"/> of <see cref="string"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The type of object to process.</typeparam>
+        /// <param name="optionType">An <see cref="OptionType"/> that controls the conversion.</param>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> that contains the objects to process.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentException">If <seealso cref="OptionType.Type"/> cannot be assigned to <typeparamref name="TBase"/>.</exception>
+        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
+        private IEnumerable<string> ConvertFrom<TBase>(OptionType optionType, IEnumerable<TBase> values)
+            where TBase : class =>  //  can't use a new() contraint as TBase may well be abstract
+            ConvertFrom<TBase>(optionType.Type, values);
+
+        /// <summary>
+        /// Converts the specified <paramref name="values"/> of type <paramref name="type"/> into
+        /// an <see cref="IEnumerable{T}"/> of <see cref="string"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The type of object to process.</typeparam>
+        /// <param name="type">The <see cref="Type"/> of object; it must be assignable to <typeparamref name="TBase"/>.</param>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> that contains the objects to process.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
+        /// <exception cref="ArgumentException">If <seealso cref="OptionType.Type"/> cannot be assigned to <typeparamref name="TBase"/>.</exception>
+        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
+        /// <remarks>This routine calls its namesake by reflection.</remarks>
+        private IEnumerable<string> ConvertFrom<TBase>(Type type, IEnumerable<TBase> values)
+            where TBase : class //  can't use a new() contraint as TBase may well be abstract
+        {
+            if (!type.IsAssignableTo(typeof(TBase)))
+                throw new ArgumentException(
+                    $"Unable to assign an object of type {type.Name} to {typeof(TBase).Name}.");
+
+            var name = nameof(ConvertFrom);
+
+            var returnType = typeof(IEnumerable<>).MakeGenericType(typeof(string));
+
+            // Filter the parameters to those just of the type we're currently working with.
+            var parameters = new object[]
+                {
+                    values
+                        .Where(n => n?.GetType().Equals(type) ?? false)
+                        .ToList(),
+                    type,
+                };
+
+            // Explicitly set the types, rather than relying on the type of each parameter.
+            var types =
+                new[]
+                {
+                    typeof(IEnumerable<>).MakeGenericType(typeof(TBase)),
+                    typeof(Type),
+                };
+
+            // name is the name of the method to retrieve.
+            // type is the generic type parameter.
+            // returnType is the type of the return parameter.
+            // types are the types of the parameters the method expects.
+            var method = GetType().GetGenericMethod(name, typeof(TBase), returnType, types);
+            var result =
+                method.Invoke(this, parameters) ??
+                throw new InvalidOperationException(
+                    $"Failed to convert from type {type.Name}.");
+
+            return (IEnumerable<string>)result;
+        }
+
+        /// <summary>
+        /// Converts the specified <paramref name="values"/> into an <see cref="IEnumerable{T}"/> 
+        /// of <see cref="string"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of object to process.</typeparam>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/> that contains the objects to process.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
+        /// <remarks>This routine is called by reflection.</remarks>
+        private IEnumerable<string> ConvertFrom<T>(IEnumerable<T> values, Type type)
+            where T : class //  can't use a new() contraint as TBase may well be abstract
+        {
+            var results = new List<string>();
+
+            var properties =
+                type.GetProperties()
+                    .Where(property => property.CanRead)
+                    .Where(property => property.CanWrite)
+                    .Where(property => property.PropertyType == typeof(string) ||
+                                       property.PropertyType.IsValueType &&
+                                       property.PropertyType != typeof(DateTime))
+                    .Select(property => new
+                    {
+                        Property = property,
+                        Depth = property.DeclaringType?.GetDepth() ?? 0,
+                    })
+                    .OrderBy(n => n.Depth)
+                    .Select(n => n.Property)
+                    .ToArray();
+            var parameters =
+                properties
+                    .Select(property =>
+                        this.options.OptionMembers
+                            .Where(assignment => assignment.Property.Name == property.Name)
+                            .Select(assignment => assignment.Name)
+                            .FirstOrDefault() ??
+                        property.GetCustomAttribute<CsvConverterPropertyAttribute>()?.Name ??
+                        property.Name)
+                    .ToArray();
+
+            var typeName =
+                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+                type.Name;
+
+            results.Add(ConverterHelper.FormatCsvData(this.options.PropertyPrefix, typeName, parameters)); //  ConvertFrom
+            foreach (var value in values)
+            {
+                var asStrings = ConverterHelper.AsStrings(value, properties);
+                results.Add(ConverterHelper.FormatCsvData(this.options.ValuesPrefix, typeName, asStrings.ToArray()));
+            }
+
+            return results;
+        }
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter/ValueConverter.cs
+++ b/Crowswood.CsvConverter/ValueConverter.cs
@@ -9,6 +9,7 @@ namespace Crowswood.CsvConverter
     {
         #region Fields
 
+        private readonly ConversionHandler conversionHandler;
         private readonly IndexHandler indexHandler;
         private readonly string typeName;
 
@@ -16,8 +17,9 @@ namespace Crowswood.CsvConverter
 
         #region Constructors
 
-        internal ValueConverter(IndexHandler indexHandler, string typeName)
+        internal ValueConverter(ConversionHandler conversionHandler, IndexHandler indexHandler, string typeName)
         {
+            this.conversionHandler = conversionHandler;
             this.indexHandler = indexHandler;
             this.typeName = typeName;
         }
@@ -38,7 +40,8 @@ namespace Crowswood.CsvConverter
         {
             if (targetType == typeof(string))
                 // Remove any white space surrounding the value, then remove the double-quotes.
-                return textValue.Trim().Trim('"').Trim();
+                // Finally do any value conversion.
+                return this.conversionHandler.ConvertValue(textValue.Trim().Trim('"').Trim());
             if (!targetType.IsValueType || targetType == typeof(DateTime))
                 throw new ArgumentException("Must be either a string, enum or numeric type.",
                     nameof(targetType));


### PR DESCRIPTION
Add ConversionType and ConversionValue model classes. Rename ConversionHelper to ConverterHelper. This will allow a new ConversionHelpter static class to target the type and value conversion functionality. While the ConverterHelpter targets the Converter class.

[REFACTOR] Add helpers

Add ConfigHelper and MetadataHelper.

[FEATURE] Add ConversionHandler and ConversionHelper classes

Add the ConversionHandler class to parse the lines for conversion types and values, hold them for future use and manage the conversions. Add the ConversionHelper class to support the construction of arrays of ConversionType and ConvertionValue objects. Update Options to specify the prefixes and whether conversions are enabled or not. Update ConfigHandler to support Conversion prefixes and enabled flags.

[TEST] Add tests

Add test for ConversionType and ConversionValue model objects; Handler constructor, options including defalts, enable / disable conversion, and prefixes; Handler conversion methods.

[FEATURE] Add use of conversion functionality to converter

Update Converter to use the ConversionHandler for both types and values. Inject the ConversionHandler into the ValueConverter so it can request the value conversion when converting a string value. Inject the ConversionHandler into the MetadataHandler so it can pass it to the ValueConverter it uses. Convert the type name when generating the dictionary of Typeless values.

[TESTS] Add tests

Add tests to confirm that typed results have values conversions applied if enabled, but not if disabled. Ditto typeless results. And that typeless results have typename conversions applied if enabled but not if disabled.

[REFACTOR] Split serialization and deserialisation out to their own processors

Created SerializationProcessor and DeserializationProcessor. Separated the orchestration of the handlers from the serialization / deserialization process. The Converter class now only does the orchestration.