### PR TITLE
[TEST]{FIX] Various real-world bug fixes and tests to exercise them

### DIFF
--- a/.github/workflows/build+test-on-dotnet.yml
+++ b/.github/workflows/build+test-on-dotnet.yml
@@ -11,11 +11,12 @@ on:
 
 jobs:
   build:
-
+    name: build-test-linux
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Xml.Serialization;
+
+namespace Crowswood.CsvConverter.Tests.ConverterTests
+{
+    [TestClass]
+    public class ConverterTests
+    {
+        [TestMethod]
+        public void TypelessJustTrackTest()
+        {
+            var text = @"
+Properties,Connection,Name,            End1, End2, Exit1,Exit2,Group,IsRouteEndpoint
+Values,    Connection,""Piece of Track"",""TE1"",""TE2"",0,    0,    """",   false
+
+Properties,TrackNode,Id,   Name,  NodeType,  Address,Group,Orientation,PositionX,PositionY,IsTrapPoint
+Values,    TrackNode,""TE1"",""TE 1"",""TrackEnd"","""",     """",   """",         0,        0,        false
+Values,    TrackNode,""TE2"",""TE 2"",""TrackEnd"","""",     """",   """",         0,        0,        false
+";
+            var options =
+                new Options()
+                    .ForType("Connection", "Name", "End1", "End2", "Exit1", "Exit2", "Group", "IsRouteEndpoint")
+                    .ForType("TrackNode", "Id", "Name", "NodeType", "Address", "Group", "Orientation", "PositionX", "PosistionY", "IsTrapPoint");
+            var converter = new Converter(options);
+
+            var data = converter.Deserialize(text);
+
+            Assert.IsNotNull(data);
+        }
+
+        [TestMethod]
+        public void TypedJustTrackTest()
+        {
+            var text = @"
+Properties,Connection,Name,            End1, End2, Exit1,Exit2,Group,IsRouteEndpoint
+Values,    Connection,""Piece of Track"",""TE1"",""TE2"",0,    0,    """",   false
+
+Properties,TrackNode,Id,   Name,  NodeType,  Address,Group,Orientation,PositionX,PositionY,IsTrapPoint
+Values,    TrackNode,""TE1"",""TE 1"",""TrackEnd"","""",     """",   """",         0,        0,        false
+Values,    TrackNode,""TE2"",""TE 2"",""TrackEnd"","""",     """",   """",         0,        0,        false
+";
+            var options =
+                new Options()
+                    .ForType<Connection>()
+                    .ForType<FeatureNode>()
+                    .ForType<TrackNode>();
+            var converter = new Converter(options);
+
+            var data = converter.Deserialize<BaseEntity>(text);
+
+            Assert.IsNotNull(data);
+        }
+
+        #region Model class
+
+        public class BaseEntity
+        {
+            [XmlElement(nameof(Group))]
+            public string Group { get; set; } = string.Empty;
+
+            [XmlElement(nameof(Name))]
+            public string Name { get; set; } = string.Empty;
+        }
+
+        public class Connection : BaseEntity
+        {
+            [XmlElement(nameof(End1))]
+            public string End1 { get; set; } = string.Empty;
+
+            [XmlElement(nameof(End2))]
+            public string End2 { get; set; } = string.Empty;
+
+            [XmlElement(nameof(EnforceEndpoint))]
+            public bool EnforceEndpoint { get; set; }
+
+            [XmlElement(nameof(Exit1))]
+            public int? Exit1 { get; set; }
+
+            [XmlElement(nameof(Exit2))]
+            public int? Exit2 { get; set; }
+
+            [XmlElement(nameof(IsRouteEndpoint))]
+            public bool IsRouteEndpoint { get; set; }
+        }
+
+        public class BaseEntityNode : BaseEntity
+        {
+            [XmlElement(nameof(NodeType))]
+            public string NodeType { get; set; } = string.Empty;
+
+            [XmlElement(nameof(Id))]
+            public string Id { get; set; } = string.Empty;
+
+            [XmlElement(nameof(Address))]
+            public string Address { get; set; } = string.Empty;
+
+            [XmlElement(nameof(Orientation))]
+            public string Orientation { get; set; } = string.Empty;
+
+            [XmlElement(nameof(PositionX))]
+            public int PositionX { get; set; }
+
+            [XmlElement(nameof(PositionY))]
+            public int PositionY { get; set; }
+        }
+
+        public class FeatureNode : BaseEntityNode
+        {
+            [XmlElement(nameof(SubType))]
+            public string SubType { get; set; } = string.Empty;
+        }
+
+        public class TrackNode : BaseEntityNode
+        {
+            public static TrackNode Undefined { get; } = new();
+
+            [XmlElement(nameof(IsTrapPoint))]
+            public bool IsTrapPoint { get; set; } = false;
+        }
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter.Tests/Crowswood.CsvConverter.Tests.csproj
+++ b/Crowswood.CsvConverter.Tests/Crowswood.CsvConverter.Tests.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Crowswood.CsvConverter/Converter.cs
+++ b/Crowswood.CsvConverter/Converter.cs
@@ -4,7 +4,8 @@ using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Processors;
 
-[assembly: InternalsVisibleTo("Crowswood.CsvConverter.Tests")]
+[assembly: 
+    InternalsVisibleTo("Crowswood.CsvConverter.Tests")]
 
 namespace Crowswood.CsvConverter
 {
@@ -56,6 +57,31 @@ namespace Crowswood.CsvConverter
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Determines and returns whether the specified <paramref name="text"/> appears to be 
+        /// valid CSV.
+        /// </summary>
+        /// <param name="text">A <see cref="string"/> that contains the text to check.</param>
+        /// <returns>True if the text appears to be valid CSV; false otherwise.</returns>
+        public bool Check(string text)
+        {
+            ValidateText(text);
+            var trimmedText = text.Trim();
+
+            // Specifically exclude text that looks like either JSON or XML.
+            if (trimmedText.StartsWith('{') && trimmedText.EndsWith('}')) return false;
+            if (trimmedText.StartsWith('[') && trimmedText.EndsWith(']')) return false;
+            if (trimmedText.StartsWith('<') && trimmedText.EndsWith('>')) return false;
+
+            var lines = SplitLines(text);
+
+            // Are there at least two lines, and do they all, once comments and blank lines have
+            // been removed, contain a comma?
+            return 
+                lines.Count >= 2 &&
+                lines.All(line => line.Contains(','));
+        }
 
         /// <summary>
         /// Deserialize the specified <paramref name="text"/> into an <see cref="IEnumerable{T}"/> 

--- a/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
+++ b/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
@@ -1,9 +1,49 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>Crowswood.CsvConverter</Title>
+    <Description>A compact and simple conversion library that supports multiple data types, metadata, configuration, comments and more within a single CSV file.</Description>
+    <PackageProjectUrl>https://github.com/RichardCrawshaw/Crowswood.CsvConverter</PackageProjectUrl>
+    <Copyright>Richard Crawshaw</Copyright>
+    <Company>Crowswood</Company>
+    <RepositoryUrl>https://github.com/RichardCrawshaw/Crowswood.CsvConverter</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>CSV;Converter;Serialize;Deserialize;Serialise;Deserialise</PackageTags>
+    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <PackageVersion>$(Version)</PackageVersion>
+    <Version>0.6.2-beta-02</Version>
+    <AssemblyVersion>0.6.1</AssemblyVersion>
+    <Configurations>Debug;Release</Configurations>
+    <PackageOutputPath>$(OutputPath)</PackageOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Deterministic>False</Deterministic>
+    <ShouldCreateLogs>True</ShouldCreateLogs>
+    <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
+    <UpdateAssemblyVersion>False</UpdateAssemblyVersion>
+    <UpdateAssemblyFileVersion>False</UpdateAssemblyFileVersion>
+    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
+    <UpdatePackageVersion>False</UpdatePackageVersion>
+    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
+    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <Deterministic>False</Deterministic>
+    <ShouldCreateLogs>True</ShouldCreateLogs>
+    <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
+    <UpdateAssemblyVersion>False</UpdateAssemblyVersion>
+    <UpdateAssemblyFileVersion>False</UpdateAssemblyFileVersion>
+    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
+    <UpdatePackageVersion>True</UpdatePackageVersion>
+    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
+    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
+    <PackageVersionSettings>AssemblyVersion.NoneWithAutoReset.Beta</PackageVersionSettings>
   </PropertyGroup>
 
 </Project>

--- a/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Crowswood.CsvConverter.Model;
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Model;
 
 namespace Crowswood.CsvConverter.Extensions
 {
@@ -46,7 +47,8 @@ namespace Crowswood.CsvConverter.Extensions
         /// <param name="type">A <see cref="Type"/>.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="PropertyAndAttributePair"/> objects.</returns>
         public static IEnumerable<PropertyAndAttributePair> GetPropertyAndAttributePairs(this Type type) =>
-            type.GetProperties()
+            type.GetProperties(BindingFlags.Instance |
+                               BindingFlags.Public)
                 .Select(property => new PropertyAndAttributePair(property));
 
         /// <summary>

--- a/Crowswood.CsvConverter/ValueConverter.cs
+++ b/Crowswood.CsvConverter/ValueConverter.cs
@@ -43,7 +43,8 @@ namespace Crowswood.CsvConverter
                 // Finally do any value conversion.
                 return this.conversionHandler.ConvertValue(textValue.Trim().Trim('"').Trim());
             if (!targetType.IsValueType || targetType == typeof(DateTime))
-                throw new ArgumentException("Must be either a string, enum or numeric type.",
+                throw new ArgumentException(
+                    $"Must be either a string, enum or numeric type: {targetType.Name}.",
                     nameof(targetType));
 
             if (targetType == typeof(bool))


### PR DESCRIPTION
Add retrieval of only instance properties when retrieving PropertyAndAttributePair objects. Add filtering out of types that aren't present in the CSV when constructing typeless data prior to converting to typed data. Add method to check to see if the text looks like it could be CSV data. Add PropertyGroup elements to support the generation of a NuGet package. Add tests.