### PR TITLE
[FEATURE][TESTS] Fluent serialization

### DIFF
--- a/Crowswood.CsvConverter.Tests/ConverterTests/ConverterSerializeTests.cs
+++ b/Crowswood.CsvConverter.Tests/ConverterTests/ConverterSerializeTests.cs
@@ -1,0 +1,864 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+
+namespace Crowswood.CsvConverter.Tests.ConverterTests
+{
+    [TestClass]
+    public class ConverterSerializeTests
+    {
+        private readonly bool logSerializedOutput = false;
+
+        // Note the `\r?$` on the end of the pattern. This is due to `$` matching either `\n` 
+        // or the end of the input string, but NOT matching `\r`, AND under Windows there 
+        // being `\r\n` as the line terminator. See:
+        // https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options#multiline-mode
+        private const string PATTERN = "^{0}\r?$";
+        private const string EXPECTED_MESSAGE = "Failed to find {0}.";
+        private const string UNWANTED_MESSAGE = "Found {0}.";
+
+        [TestMethod]
+        public void NoDataTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+            Assert.IsTrue(string.IsNullOrEmpty(text), 
+                "Serialization with no data does not produce empty result.");
+        }
+
+        [TestMethod]
+        public void BlankLineTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .BlankLine(2)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            Assert.IsFalse(string.IsNullOrEmpty(text), "Serialize two blank lines produced empty text.");
+            Assert.IsTrue(string.IsNullOrWhiteSpace(text), "Serialize two blank line did not produced whitespace.");
+        }
+
+        [TestMethod]
+        public void CommentTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+
+            var prefix = "#";
+            var comment = "This is a comment.";
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .Comment(prefix, comment)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Comment"] = "# This is a comment.",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void EmptyGlobalConfigTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+            var config =
+                new Dictionary<string, string>();
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .GlobalConfig(config)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            Assert.IsTrue(string.IsNullOrEmpty(text), "No global config gives non-empty result.");
+        }
+
+        [TestMethod]
+        public void GlobalConfigTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+
+            var globalConfig = 
+                new Dictionary<string, string>
+                {
+                    [Converter.Keys.GlobalConfig.ConversionTypePrefix] = "AAA",
+                    [Converter.Keys.GlobalConfig.ConversionValuePrefix] = "BBB",
+                    [Converter.Keys.GlobalConfig.PropertyPrefix] = "CCC",
+                    [Converter.Keys.GlobalConfig.ReferenceIdColumnName] = "DDD",
+                    [Converter.Keys.GlobalConfig.ReferenceNameColumnName] = "EEE",
+                    [Converter.Keys.GlobalConfig.ValuesPrefix] = "FFF",
+                    ["Rubbish"] = "aaa",
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .GlobalConfig(globalConfig)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["GlobalConfig ConversionTypePrefix"] = "GlobalConfig,ConversionTypePrefix,AAA",
+                ["GlobalConfig ConversionValuePrefix"] = "GlobalConfig,ConversionValuePrefix,BBB",
+                ["GlobalConfig PropertyPrefix"] = "GlobalConfig,PropertyPrefix,CCC",
+                ["GlobalConfig ReferenceIdColumnName"] = "GlobalConfig,ReferenceIdColumnName,DDD",
+                ["GlobalConfig ReferenceNameColumnName"] = "GlobalConfig,ReferenceNameColumnName,EEE",
+                ["GlobalConfig ValuesPrefix"] = "GlobalConfig,ValuesPrefix,FFF",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+
+            Dictionary<string, string> unwanted = new()
+            {
+                ["Invalid GlobalConfig"] = "GlobalConfig,Rubbish,.*",
+            };
+
+            foreach (var check in unwanted)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsFalse(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    UNWANTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypedConfigTest()
+        {
+            // Arrange
+            var options =
+                Options.None;
+            var converter = new Converter(options);
+
+            var typedConfig =
+                new Dictionary<string, string>
+                {
+                    [Converter.Keys.TypedConfig.ConversionTypePrefix] = "AAA",
+                    [Converter.Keys.TypedConfig.ConversionValuePrefix] = "BBB",
+                    [Converter.Keys.TypedConfig.PropertyPrefix] = "CCC",
+                    [Converter.Keys.TypedConfig.ReferenceIdColumnName] = "DDD",
+                    [Converter.Keys.TypedConfig.ReferenceNameColumnName] = "EEE",
+                    [Converter.Keys.TypedConfig.ValuesPrefix] = "FFF",
+                    ["Rubbish"] = "aaa",
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .TypeConfig<Foo>(typedConfig)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["TypedConfig Foo ConversionTypePrefix"] = "TypedConfig,Foo,ConversionTypePrefix,AAA",
+                ["TypedConfig Foo ConversionValuePrefix"] = "TypedConfig,Foo,ConversionValuePrefix,BBB",
+                ["TypedConfig Foo PropertyPrefix"] = "TypedConfig,Foo,PropertyPrefix,CCC",
+                ["TypedConfig Foo ReferenceIdColumnName"] = "TypedConfig,Foo,ReferenceIdColumnName,DDD",
+                ["TypedConfig Foo ReferenceNameColumnName"] = "TypedConfig,Foo,ReferenceNameColumnName,EEE",
+                ["TypedConfig Foo ValuesPrefix"] = "TypedConfig,Foo,ValuesPrefix,FFF",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+
+            Dictionary<string, string> unwanted = new()
+            {
+                ["Invalid GlobalConfig"] = "TypedConfig,Foo,Rubbish,.*",
+            };
+
+            foreach (var check in unwanted)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsFalse(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    UNWANTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypeConversionTest()
+        {
+            // Arrange
+            var options = Options.None;
+            var converter = new Converter(options);
+
+            var typeConversion =
+                new Dictionary<string, string>
+                {
+                    ["Foo"] = "Bar",
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .TypeConversion(typeConversion)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["TypeConversion 'Foo' to 'Bar'"] = "ConversionTypePrefix,\"Foo\",\"Bar\"",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void ValueConversionTest()
+        {
+            // Arrange
+            var options = Options.None;
+            var converter = new Converter(options);
+
+            var valueConversion =
+                new Dictionary<string, string>
+                {
+                    ["Foo"] = "Bar",
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .ValueConversion(valueConversion)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["ValueConversion 'Foo' to 'Bar'"] = "ConversionValuePrefix,\"Foo\",\"Bar\"",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypedMetadataTest()
+        {
+            // Arrange
+            const string metadataPrefix = "Metadata";
+            var propertyNames = new[] { "Name", "Number", };
+            var options =
+                new Options()
+                    .ForMetadata<SomeMetadata>(metadataPrefix, propertyNames[0], propertyNames[1]);
+            var converter = new Converter(options);
+
+            var metadata =
+                new List<SomeMetadata>
+                {
+                    new SomeMetadata{ Name = "ABC", Number = 1, },
+                    new SomeMetadata{ Name = "XYZ", Number = 99, },
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .TypedMetadata<Foo, SomeMetadata>(metadata)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Foo Metadata 'ABC'"] = "Metadata,Foo,\"ABC\",1",
+                ["Foo Metadata 'XYZ'"] = "Metadata,Foo,\"XYZ\",99",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypelessMetadataTest()
+        {
+            // Arrange
+            var prefix = "typelessMD";
+            var propertyNames = new[] { "Name", "Number", };
+            var options =
+                new Options()
+                    .ForMetadata(prefix, true, propertyNames);
+            var converter = new Converter(options);
+
+            var metadata =
+                new Dictionary<string, string>
+                {
+                    [propertyNames[0]] = "Fred",
+                    [propertyNames[1]] = 77.ToString(),
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .TypelessMetadata("Foo", prefix, metadata)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Typeless Metadata"] = "typelessMD,Foo,\"Fred\",\"77\"",
+            };
+
+            Assert.AreEqual(checks.Count, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypedDataTest()
+        {
+            // Arrange
+            var options = Options.None;
+            var converter = new Converter(options);
+
+            var fooData =
+                new List<Foo>
+                {
+                    new Foo { Id = 1, Name = "Fred", Value = "East", },
+                    new Foo { Id = 2, Name = "Bert", Value = "West", },
+                };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .TypedData<Foo>(fooData)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Foo properties"] = "Properties,Foo,Id,Name,Value",
+                ["Foo value 1"] = "Values,Foo,1,\"Fred\",\"East\"",
+                ["Foo value 2"] = "Values,Foo,2,\"Bert\",\"West\"",
+            };
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void TypelessDataTest()
+        {
+            // Arrange
+            var options =
+                new Options()
+                    .ForType<Foo>();
+            var converter = new Converter(options);
+
+            var names = new[] { "Id", "Name", "Value", };
+            List<string[]> values = new()
+            {
+                new[] { "1", "Fred", "East", },
+                new[] { "2", "Bert", "West", }
+            };
+
+            // Act
+            var text=
+                converter
+                    .Serialize()
+                    .TypelessData("SomeDataType", names, values)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Properties"] = "Properties,SomeDataType,Id,Name,Value",
+                ["Value 1"] = "Values,SomeDataType,\"1\",\"Fred\",\"East\"",
+                ["Value 2"] = "Values,SomeDataType,\"2\",\"Bert\",\"West\"",
+            };
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void FullTypedTest()
+        {
+            // Arrange
+            const string metadataPrefix = "Metadata";
+            var propertyNames = new[] { "Name", "Number", };
+            var options =
+                new Options()
+                    .ForMetadata<SomeMetadata>(metadataPrefix, propertyNames[0], propertyNames[1])
+                    .ForType<Foo>();
+            var converter = new Converter(options);
+
+            var openingComment = "This is the Full Typed Test.";
+            var globalConfigComment = "Here is the global configuration.";
+            Dictionary<string, string> globalConfiguration = new()
+            {
+                [Converter.Keys.GlobalConfig.ConversionTypePrefix] = "AAA",
+                [Converter.Keys.GlobalConfig.ConversionValuePrefix] = "BBB",
+                [Converter.Keys.GlobalConfig.PropertyPrefix] = "CCC",
+                [Converter.Keys.GlobalConfig.ReferenceIdColumnName] = "DDD",
+                [Converter.Keys.GlobalConfig.ReferenceNameColumnName] = "EEE",
+                [Converter.Keys.GlobalConfig.ValuesPrefix] = "FFF",
+            };
+            var typeConfigComment = "Here is the type configuration.";
+            Dictionary<string, string> fooTypeConfiguration = new()
+            {
+                [Converter.Keys.TypedConfig.ConversionTypePrefix] = "aaa",
+                [Converter.Keys.TypedConfig.ConversionValuePrefix] = "bbb",
+                [Converter.Keys.TypedConfig.PropertyPrefix] = "ccc",
+                [Converter.Keys.TypedConfig.ReferenceIdColumnName] = "ddd",
+                [Converter.Keys.TypedConfig.ReferenceNameColumnName] = "eee",
+                [Converter.Keys.TypedConfig.ValuesPrefix] = "fff",
+            };
+            var typeConversionComment = "Here are some type conversions.";
+            Dictionary<string, string> typeConversion = new()
+            {
+                ["Foo"] = "Bar",
+            };
+            var valueConversionComment = "Here are some value conversions.";
+            Dictionary<string, string> valueConversion = new()
+            {
+                ["Foo"] = "Bar",
+            };
+            var fooDataComment = "Here is the Foo data preceeded by some metadata.";
+            List<SomeMetadata> fooMetadata = new()
+            {
+                new SomeMetadata{ Name = "ABC", Number = 1, },
+                new SomeMetadata{ Name = "XYZ", Number = 99, },
+            };
+            List<Foo> fooData = new()
+            {
+                new Foo { Id = 1, Name = "Fred", Value = "East", },
+                new Foo { Id = 2, Name = "Bert", Value = "West", },
+            };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .Comment("#", openingComment)
+                    .BlankLine()
+                    .Comment("#", globalConfigComment)
+                    .GlobalConfig(globalConfiguration)
+                    .BlankLine()
+                    .Comment("#", typeConfigComment)
+                    .TypeConfig<Foo>(fooTypeConfiguration)
+                    .BlankLine()
+                    .Comment("#", typeConversionComment)
+                    .TypeConversion(typeConversion)
+                    .BlankLine()
+                    .Comment("#", valueConversionComment)
+                    .ValueConversion(valueConversion)
+                    .BlankLine()
+                    .Comment("#", fooDataComment)
+                    .TypedMetadata<Foo, SomeMetadata>(fooMetadata)
+                    .TypedData<Foo>(fooData)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Opening comment"] = "# This is the Full Typed Test.",
+
+                ["Global config comment"] = "# Here is the global configuration.",
+                ["GlobalConfig ConversionTypePrefix"] = "GlobalConfig,ConversionTypePrefix,AAA",
+                ["GlobalConfig ConversionValuePrefix"] = "GlobalConfig,ConversionValuePrefix,BBB",
+                ["GlobalConfig PropertyPrefix"] = "GlobalConfig,PropertyPrefix,CCC",
+                ["GlobalConfig ReferenceIdColumnName"] = "GlobalConfig,ReferenceIdColumnName,DDD",
+                ["GlobalConfig ReferenceNameColumnName"] = "GlobalConfig,ReferenceNameColumnName,EEE",
+                ["GlobalConfig ValuesPrefix"] = "GlobalConfig,ValuesPrefix,FFF",
+
+                ["Type config comment"] = "# Here is the type configuration.",
+                ["TypedConfig Foo ConversionTypePrefix"] = "TypedConfig,Foo,ConversionTypePrefix,aaa",
+                ["TypedConfig Foo ConversionValuePrefix"] = "TypedConfig,Foo,ConversionValuePrefix,bbb",
+                ["TypedConfig Foo PropertyPrefix"] = "TypedConfig,Foo,PropertyPrefix,ccc",
+                ["TypedConfig Foo ReferenceIdColumnName"] = "TypedConfig,Foo,ReferenceIdColumnName,ddd",
+                ["TypedConfig Foo ReferenceNameColumnName"] = "TypedConfig,Foo,ReferenceNameColumnName,eee",
+                ["TypedConfig Foo ValuesPrefix"] = "TypedConfig,Foo,ValuesPrefix,fff",
+
+                ["Type conversion comment"] = "# Here are some type conversions.",
+                ["TypeConversion 'Foo' to 'Bar'"] = "ConversionTypePrefix,\"Foo\",\"Bar\"",
+
+                ["Value conversion comment"] = "# Here are some value conversions.",
+                ["ValueConversion 'Foo' to 'Bar'"] = "ConversionValuePrefix,\"Foo\",\"Bar\"",
+
+                ["Foo data comment"] = "# Here is the Foo data preceeded by some metadata.",
+                ["Foo Metadata 'ABC'"] = "Metadata,Foo,\"ABC\",1",
+                ["Foo Metadata 'XYZ'"] = "Metadata,Foo,\"XYZ\",99",
+                ["Foo properties"] = "Properties,Foo,Id,Name,Value",
+                ["Foo value 1"] = "Values,Foo,1,\"Fred\",\"East\"",
+                ["Foo value 2"] = "Values,Foo,2,\"Bert\",\"West\"",
+            };
+
+            var expectedLineCount =
+                1 + // opening comment
+                1 + // blank line
+                1 + // global config comment
+                globalConfiguration.Count +
+                1 + // blank line
+                1 + // type config comment
+                fooTypeConfiguration.Count +
+                1 + // blank line
+                1 + // type conversion comment
+                typeConversion.Count +
+                1 + // blank line
+                1 + // value conversion comment
+                valueConversion.Count +
+                1 + // blank line
+                1 + // foo data comment
+                fooMetadata.Count +
+                1 + // foo properties
+                fooData.Count;
+            var expectedNumberOfCommentLines =
+                1 + // opening comment
+                1 + // global config comment
+                1 + // type config comment
+                1 + // type conversion comment
+                1 + // value conversion comment
+                1 + // foo data comment
+                0;
+
+            Assert.AreEqual(expectedLineCount, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            Assert.AreEqual(expectedNumberOfCommentLines,
+                Regex.Matches(text, "(?:\r?\n){0,2}# ").Count,
+                "Unexpected number of comments.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        [TestMethod]
+        public void FullTypelessTest()
+        {
+            // Arrange
+            const string metadataPrefix = "Metadata";
+            var metadataPropertyNames = new[] { "Name", "Number", };
+            const string fooName = "Foo";
+            var fooPropertyNames = new[] { "Id", "Name", "Value", };
+            var options =
+                new Options()
+                    .ForMetadata(metadataPrefix, allowNulls: true, metadataPropertyNames[0], metadataPropertyNames[1])
+                    .ForType(fooName, fooPropertyNames[0], fooPropertyNames[1..]);
+            var converter = new Converter(options);
+
+            var openingComment = "This is the Full Typeless Test.";
+            var globalConfigComment = "Here is the global configuration.";
+            Dictionary<string, string> globalConfiguration = new()
+            {
+                [Converter.Keys.GlobalConfig.ConversionTypePrefix] = "AAA",
+                [Converter.Keys.GlobalConfig.ConversionValuePrefix] = "BBB",
+                [Converter.Keys.GlobalConfig.PropertyPrefix] = "CCC",
+                [Converter.Keys.GlobalConfig.ReferenceIdColumnName] = "DDD",
+                [Converter.Keys.GlobalConfig.ReferenceNameColumnName] = "EEE",
+                [Converter.Keys.GlobalConfig.ValuesPrefix] = "FFF",
+            };
+            var typeConfigComment = "Here is the type configuration.";
+            Dictionary<string, string> fooTypeConfiguration = new()
+            {
+                [Converter.Keys.TypedConfig.ConversionTypePrefix] = "aaa",
+                [Converter.Keys.TypedConfig.ConversionValuePrefix] = "bbb",
+                [Converter.Keys.TypedConfig.PropertyPrefix] = "ccc",
+                [Converter.Keys.TypedConfig.ReferenceIdColumnName] = "ddd",
+                [Converter.Keys.TypedConfig.ReferenceNameColumnName] = "eee",
+                [Converter.Keys.TypedConfig.ValuesPrefix] = "fff",
+            };
+            var typeConversionComment = "Here are some type conversions.";
+            Dictionary<string, string> typeConversion = new()
+            {
+                ["Foo"] = "Bar",
+            };
+            var valueConversionComment = "Here are some value conversions.";
+            Dictionary<string, string> valueConversion = new()
+            {
+                ["Foo"] = "Bar",
+            };
+            var fooDataComment = "Here is the Foo data preceeded by some metadata.";
+            Dictionary<string, string> fooMetadata = new()
+            {
+                [metadataPropertyNames[0]] = "Harry",
+                [metadataPropertyNames[1]] = 77.ToString(),
+            };
+            List<string[]> fooData = new()
+            {
+                new [] { 1.ToString(), "Fred", "East", },
+                new [] { 2.ToString(), "Bert", "West", },
+            };
+
+            // Act
+            var text =
+                converter
+                    .Serialize()
+                    .Comment("#", openingComment)
+                    .BlankLine()
+                    .Comment("#", globalConfigComment)
+                    .GlobalConfig(globalConfiguration)
+                    .BlankLine()
+                    .Comment("#", typeConfigComment)
+                    .TypeConfig<Foo>(fooTypeConfiguration)
+                    .BlankLine()
+                    .Comment("#", typeConversionComment)
+                    .TypeConversion(typeConversion)
+                    .BlankLine()
+                    .Comment("#", valueConversionComment)
+                    .ValueConversion(valueConversion)
+                    .BlankLine()
+                    .Comment("#", fooDataComment)
+                    .TypelessMetadata(fooName, metadataPrefix, fooMetadata)
+                    .TypelessData(fooName, fooPropertyNames, fooData)
+                    .Serialize();
+
+            // Assert
+            Assert.IsNotNull(text, "Failed to serialize.");
+
+            if (logSerializedOutput)
+                Logger.LogMessage("{0}", text);
+
+            Dictionary<string, string> checks = new()
+            {
+                ["Opening comment"] = "# This is the Full Typeless Test.",
+
+                ["Global config comment"] = "# Here is the global configuration.",
+                ["GlobalConfig ConversionTypePrefix"] = "GlobalConfig,ConversionTypePrefix,AAA",
+                ["GlobalConfig ConversionValuePrefix"] = "GlobalConfig,ConversionValuePrefix,BBB",
+                ["GlobalConfig PropertyPrefix"] = "GlobalConfig,PropertyPrefix,CCC",
+                ["GlobalConfig ReferenceIdColumnName"] = "GlobalConfig,ReferenceIdColumnName,DDD",
+                ["GlobalConfig ReferenceNameColumnName"] = "GlobalConfig,ReferenceNameColumnName,EEE",
+                ["GlobalConfig ValuesPrefix"] = "GlobalConfig,ValuesPrefix,FFF",
+
+                ["Type config comment"] = "# Here is the type configuration.",
+                ["TypedConfig Foo ConversionTypePrefix"] = "TypedConfig,Foo,ConversionTypePrefix,aaa",
+                ["TypedConfig Foo ConversionValuePrefix"] = "TypedConfig,Foo,ConversionValuePrefix,bbb",
+                ["TypedConfig Foo PropertyPrefix"] = "TypedConfig,Foo,PropertyPrefix,ccc",
+                ["TypedConfig Foo ReferenceIdColumnName"] = "TypedConfig,Foo,ReferenceIdColumnName,ddd",
+                ["TypedConfig Foo ReferenceNameColumnName"] = "TypedConfig,Foo,ReferenceNameColumnName,eee",
+                ["TypedConfig Foo ValuesPrefix"] = "TypedConfig,Foo,ValuesPrefix,fff",
+
+                ["Type conversion comment"] = "# Here are some type conversions.",
+                ["TypeConversion 'Foo' to 'Bar'"] = "ConversionTypePrefix,\"Foo\",\"Bar\"",
+
+                ["Value conversion comment"] = "# Here are some value conversions.",
+                ["ValueConversion 'Foo' to 'Bar'"] = "ConversionValuePrefix,\"Foo\",\"Bar\"",
+
+                ["Foo data comment"] = "# Here is the Foo data preceeded by some metadata.",
+                ["Foo Metadata 'Harry'"] = "Metadata,Foo,\"Harry\",\"77\"",
+                ["Foo properties"] = "Properties,Foo,Id,Name,Value",
+                ["Foo value 1"] = "Values,Foo,\"1\",\"Fred\",\"East\"",
+                ["Foo value 2"] = "Values,Foo,\"2\",\"Bert\",\"West\"",
+            };
+
+            var expectedLineCount =
+                1 + // opening comment
+                1 + // blank line
+                1 + // global config comment
+                globalConfiguration.Count +
+                1 + // blank line
+                1 + // type config comment
+                fooTypeConfiguration.Count +
+                1 + // blank line
+                1 + // type conversion comment
+                typeConversion.Count +
+                1 + // blank line
+                1 + // value conversion comment
+                valueConversion.Count +
+                1 + // blank line
+                1 + // foo data comment
+                1 + // fooMetadata
+                1 + // foo properties
+                fooData.Count;
+            var expectedNumberOfCommentLines =
+                1 + // opening comment
+                1 + // global config comment
+                1 + // type config comment
+                1 + // type conversion comment
+                1 + // value conversion comment
+                1 + // foo data comment
+                0;
+
+            Assert.AreEqual(expectedLineCount, text.Split(Environment.NewLine).Length,
+                "Unexpected number of lines.");
+
+            Assert.AreEqual(expectedNumberOfCommentLines,
+                Regex.Matches(text, "(?:\r?\n){0,2}# ").Count,
+                "Unexpected number of comments.");
+
+            foreach (var check in checks)
+            {
+                var pattern = string.Format(PATTERN, check.Value);
+                Assert.IsTrue(Regex.IsMatch(text, pattern, RegexOptions.Multiline),
+                    EXPECTED_MESSAGE, check.Key);
+            }
+        }
+
+        #region Model
+
+        private class Foo
+        {
+            public int Id { get; set; }
+
+            public string? Name { get; set; }
+
+            public string? Value { get; set; }
+        }
+
+        private class SomeMetadata
+        {
+            public string? Name { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Crowswood.CsvConverter.Tests/OptionsTests.cs
+++ b/Crowswood.CsvConverter.Tests/OptionsTests.cs
@@ -114,9 +114,9 @@
             Assert.AreEqual(1, options.OptionMetadata.Length, "Unexpected number of Metadata.");
             Assert.AreEqual(typeof(OptionsBar), options.OptionMetadata[0].Type, "Unexpected OptionMetadata 0 Type.");
             Assert.AreEqual("Foo", options.OptionMetadata[0].Prefix, "Unexpected OptionMetadata 0 Prefix.");
-            Assert.AreEqual(typeof(OptionMetadata<OptionsBar>), options.OptionMetadata[0].GetType(), "Unexpected OptionMetadata 0 generic type.");
+            Assert.AreEqual(typeof(OptionTypedMetadata<OptionsBar>), options.OptionMetadata[0].GetType(), "Unexpected OptionMetadata 0 generic type.");
             Assert.IsTrue(
-                ((OptionMetadata<OptionsBar>)options.OptionMetadata[0]).PropertyNames
+                ((OptionTypedMetadata<OptionsBar>)options.OptionMetadata[0]).PropertyNames
                     .GroupBy(propertyName => propertyName)
                     .ToDictionary(n => n.Key, n => n.Count())
                     .All(kvp => (kvp.Key == "Bar" && kvp.Value == 1) ||

--- a/Crowswood.CsvConverter/Converter.cs
+++ b/Crowswood.CsvConverter/Converter.cs
@@ -2,7 +2,9 @@
 using System.Runtime.CompilerServices;
 using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Interfaces;
 using Crowswood.CsvConverter.Processors;
+using static Crowswood.CsvConverter.Handlers.ConfigHandler;
 
 [assembly: 
     InternalsVisibleTo("Crowswood.CsvConverter.Tests")]
@@ -198,6 +200,54 @@ namespace Crowswood.CsvConverter
             return result;
         }
 
+        /// <summary>
+        /// Initialises and retrieves an <see cref="ISerialization"/> object that can be used to 
+        /// manage the serialization of multiple objects, including configuration, conversions, 
+        /// typed and typeless metadata, typed and typeless data, and comments.
+        /// </summary>
+        /// <returns>An <see cref="ISerialization"/> object.</returns>
+        public ISerialization Serialize() => new Serialization(this, this.options);
+
+        #endregion
+
+        #region Nested classes
+
+        /// <summary>
+        /// Class that defines the keys used in the data dictionaries.
+        /// </summary>
+        public static class Keys
+        {
+            /// <summary>
+            /// Keys used in the global config data dictionary.
+            /// </summary>
+            public static class GlobalConfig
+            {
+                public const string ConversionTypePrefix = Configurations.ConversionTypePrefix;
+                public const string ConversionValuePrefix = Configurations.ConversionValuePrefix;
+                public const string PropertyPrefix = Configurations.PropertyPrefix;
+                public const string ReferenceIdColumnName = Configurations.ReferenceIdColumnName;
+                public const string ReferenceNameColumnName = Configurations.ReferenceNameColumnName;
+                public const string ValuesPrefix = Configurations.ValuesPrefix;
+
+                internal const string GlobalConfigPrefix = Configurations.GlobalConfigPrefix;
+            }
+
+            /// <summary>
+            /// Keys used in the typed config data dictionary.
+            /// </summary>
+            public static class TypedConfig
+            {
+                public const string ConversionTypePrefix = Configurations.ConversionTypePrefix;
+                public const string ConversionValuePrefix = Configurations.ConversionValuePrefix;
+                public const string PropertyPrefix = Configurations.PropertyPrefix;
+                public const string ReferenceIdColumnName = Configurations.ReferenceIdColumnName;
+                public const string ReferenceNameColumnName = Configurations.ReferenceNameColumnName;
+                public const string ValuesPrefix = Configurations.ValuesPrefix;
+
+                internal const string TypedConfigPrefix = Configurations.TypedConfigPrefix;
+            }
+        }
+
         #endregion
 
         #region Support routines
@@ -236,8 +286,10 @@ namespace Crowswood.CsvConverter
         /// <param name="text">A <see cref="string"/> containing the text to split.</param>
         /// <returns>A <see cref="List{T}"/> of <see cref="string"/>.</returns>
         private List<string> SplitLines(string text) =>
+            // Split using `\r\n` CharArray rather than `Environment.NewLine` to cater for files
+            // that use a differnet standard from the current OS.
             text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries |
-                                                StringSplitOptions.TrimEntries)
+                                             StringSplitOptions.TrimEntries)
                 .Where(line => !this.options.CommentPrefixes.Any(prefix => line.StartsWith(prefix)))
                 .ToList();
 

--- a/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
+++ b/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
@@ -46,4 +46,9 @@
     <PackageVersionSettings>AssemblyVersion.NoneWithAutoReset.Beta</PackageVersionSettings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Remove="Options\Options.cs~RF10c8ef71.TMP" />
+    <None Remove="Serialization.cs~RFbb9b9a6.TMP" />
+  </ItemGroup>
+
 </Project>

--- a/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
@@ -30,6 +30,61 @@ namespace Crowswood.CsvConverter.Extensions
                 .FirstOrDefault(n => n.TypeName == typeName);
 
         /// <summary>
+        /// Gets the <see cref="OptionMember"/> element from the <paramref name="options"/> that 
+        /// has the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name.</param>
+        /// <returns>A <see cref="OptionMember"/> object, or null.</returns>
+        public static OptionMember? GetOptionMember(this Options options, string name) =>
+            options.OptionMembers
+                .FirstOrDefault(om => om.Name == name);
+
+        /// <summary>
+        /// Gets the <see cref="OptionMember"/> element from the <paramref name="options"/> that 
+        /// has a property with the same name as the specified <paramref name="property"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="property">A <see cref="PropertyInfo"/> object.</param>
+        /// <returns>A <see cref="OptionMember"/> object, or null.</returns>
+        public static OptionMember? GetOptionMember(this Options options, PropertyInfo property) =>
+            options.OptionMembers
+                .FirstOrDefault(om => om.Property.Name == property.Name);
+
+        /// <summary>
+        /// Gets the <see cref="OptionMember"/> element from the <paramref name="options"/> that 
+        /// has the specified <paramref name="type"/>,
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="OptionMember"/> object, or null.</returns>
+        public static OptionMember? GetOptionMember(this Options options, Type type) =>
+            options.OptionMembers
+                .FirstOrDefault(om => om.Type == type);
+
+        /// <summary>
+        /// Gets the <see cref="OptionMetadata"/> that has the <seealso cref="OptionMetadata.Prefix"/> 
+        /// that matches the specified <paramref name="prefix"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="prefix">A <see cref="string"/> that contains the prefix used to identify the metadata.</param>
+        /// <returns>An <see cref="OptionMetadata"/> object; or null if none match.</returns>
+        public static OptionMetadata? GetOptionMetadata(this Options options, string prefix) =>
+            options.OptionMetadata
+                .FirstOrDefault(metadata => metadata.Prefix == prefix);
+
+        /// <summary>
+        /// Gets the <see cref="OptionMetadata"/> that has the <seealso cref="OptionMetadata.Type"/> 
+        /// that matches the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>An <see cref="OptionMetadata"/> object; or null if none match.</returns>
+        public static OptionMetadata? GetOptionMetadata(this Options options, Type type) =>
+            options.OptionMetadata
+                .FirstOrDefault(metadata => metadata.Type == type);
+
+        /// <summary>
         /// Retrieves the properties of the <seealso cref="OptionMetadata.Type"/> that match the
         /// <seealso cref="OptionMetadata.PropertyNames"/>.
         /// </summary>
@@ -39,5 +94,40 @@ namespace Crowswood.CsvConverter.Extensions
             optionMetadata.Type.GetProperties()
                 .Where(property => optionMetadata.PropertyNames.Contains(property.Name))
                 .ToArray();
+
+        /// <summary>
+        /// Gets the property names from <paramref name="optionMetadata"/> for the specified 
+        /// <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="optionMetadata">The <see cref="OptionMetadata"/> array.</param>
+        /// <param name="typeName">A <see cref="string"/> that contains the name of the type.</param>
+        /// <returns>A <see cref="string[]"/> that can be null.</returns>
+        public static string[]? GetPropertyNames(this OptionMetadata[] optionMetadata, string typeName) =>
+            optionMetadata
+                .Where(om => om.Type.Name == typeName)
+                .Select(om => om.PropertyNames)
+                .FirstOrDefault();
+
+        /// <summary>
+        /// Gets the <see cref="OptionType"/> element from the <paramref name="options"/> that has 
+        /// the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name.</param>
+        /// <returns>A <see cref="OptionType"/> object, or null.</returns>
+        public static OptionType? GetOptionType(this Options options, string name) =>
+            options.OptionTypes
+                .FirstOrDefault(ot=>ot.Name == name);
+
+        /// <summary>
+        /// Gets the <see cref="OptionType"/> element from the <paramref name="options"/> that has 
+        /// the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="OptionType"/> object, or null.</returns>
+        public static OptionType? GetOptionType(this Options options, Type type) =>
+            options.OptionTypes
+                .FirstOrDefault(ot => ot.Type == type);
     }
 }

--- a/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
@@ -18,6 +18,15 @@ namespace Crowswood.CsvConverter.Extensions
             type.BaseType is null ? 0 : type.BaseType.GetDepth() + 1;
 
         /// <summary>
+        /// Extension method to determine and return the depth of the type that declares the 
+        /// <paramref name="property"/>.
+        /// </summary>
+        /// <param name="property">The <see cref="PropertyInfo"/>.</param>
+        /// <returns>An <see cref="int"/>.</returns>
+        public static int GetTypeDepth(this PropertyInfo property) =>
+            property.DeclaringType?.GetDepth() ?? 0;
+
+        /// <summary>
         /// Extension method to return the <see cref="Type"/> name in the standard readable form.
         /// </summary>
         /// <param name="type">The <see cref="Type"/>.</param>

--- a/Crowswood.CsvConverter/Handlers/ConfigHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/ConfigHandler.cs
@@ -107,7 +107,7 @@ namespace Crowswood.CsvConverter.Handlers
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
         internal string GetConversionTypePrefix() => 
             GetGlobal(Configurations.ConversionTypePrefix)?.Value ??
-            this.options.ConversionTypePrefix; // GetConversionTypePrefix
+            this.options.ConversionTypePrefix;
 
         /// <summary>
         /// Gets the conversion value prefix.
@@ -115,7 +115,7 @@ namespace Crowswood.CsvConverter.Handlers
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
         internal string GetConversionValuePrefix() =>
             GetGlobal(Configurations.ConversionValuePrefix)?.Value ??
-            this.options.ConversionValuePrefix; // GetConversionValuePrefix
+            this.options.ConversionValuePrefix;
 
         /// <summary>
         /// Gets the <see cref="GlobalConfig"/> item that has the specified <paramref name="name"/>, 
@@ -181,8 +181,8 @@ namespace Crowswood.CsvConverter.Handlers
         public string GetReferenceIdColumnName(string typeName) =>
             GetTyped(typeName, Configurations.ReferenceIdColumnName)?.Value ??
             GetGlobal(Configurations.ReferenceIdColumnName)?.Value ??
-            GetOptionReference(typeName)?.IdPropertyName ??
-            GetOptionReference()?.IdPropertyName ??
+            this.options.OptionsReferences.Get(typeName)?.IdPropertyName ??
+            this.options.OptionsReferences.Get()?.IdPropertyName ??
             Configurations.DefaultIdColumnName;
 
         /// <summary>
@@ -193,8 +193,8 @@ namespace Crowswood.CsvConverter.Handlers
         public string GetReferenceNameColumnName(string typeName) =>
             GetTyped(typeName, Configurations.ReferenceNameColumnName)?.Value ??
             GetGlobal(Configurations.ReferenceNameColumnName)?.Value ??
-            GetOptionReference(typeName)?.NamePropertyName ??
-            GetOptionReference()?.NamePropertyName ??
+            this.options.OptionsReferences.Get(typeName)?.NamePropertyName ??
+            this.options.OptionsReferences.Get()?.NamePropertyName ??
             Configurations.DefaultNameColumnName;
 
         /// <summary>
@@ -220,26 +220,6 @@ namespace Crowswood.CsvConverter.Handlers
                 this.options.ValuesPrefix,
             }.NotNull()
             .ToArray();
-
-        #endregion
-
-        #region Support routines
-
-        /// <summary>
-        /// Wrapper routine that gets the <see cref="OptionReference"/> for the default.
-        /// </summary>
-        /// <returns>An <see cref="OptionReference"/>; null if there is no default defined.</returns>
-        private OptionReference? GetOptionReference() =>
-            this.options.OptionsReferences.Get();
-
-        /// <summary>
-        /// Wrapper routine that gets the <see cref="OptionReferenceType"/> for the specified 
-        /// <paramref name="typeName"/>.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
-        /// <returns>An <see cref="OptionReferenceType"/>; null if there is nothing defined for the <paramref name="typeName"/>.</returns>
-        private OptionReferenceType? GetOptionReference(string typeName) =>
-            this.options.OptionsReferences.Get(typeName);
 
         #endregion
     }

--- a/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
@@ -158,11 +158,11 @@ namespace Crowswood.CsvConverter.Handlers
         /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="string[]"/>.</returns>
         private List<object> GetMetadata(string typeName, IEnumerable<string> lines) =>
             ConverterHelper.GetItems(lines,
-                                      rejoinSplitQuotes: true,
-                                      trimItems: false,
-                                      typeName, 
-                                      this.MetadataPrefixes)
-                .Select(items => GetMetadata(GetOptionMetadata(items[0]), items[2..^0]))
+                                     rejoinSplitQuotes: true,
+                                     trimItems: false,
+                                     typeName,
+                                     this.MetadataPrefixes)
+                .Select(items => GetMetadata(this.options.GetOptionMetadata(items[0]), items[2..^0]))
                 .NotNull()
                 .ToList();
 
@@ -186,7 +186,7 @@ namespace Crowswood.CsvConverter.Handlers
             this.indexHandler.Initialise(typeName);
 
             var valueConverter = new ValueConverter(this.conversionHandler, this.indexHandler, typeName);
-            if (optionMetadata is OptionMetadataDictionary omd)
+            if (optionMetadata is OptionTypelessMetadata omd)
             {
                 var dictionaryMetadata = 
                     MetadataHelper.GetMetadataDictionary(valueConverter,
@@ -205,16 +205,6 @@ namespace Crowswood.CsvConverter.Handlers
                                    propertyValues);
             return result;
         }
-
-        /// <summary>
-        /// Gets the <see cref="OptionMetadata"/> that has the <seealso cref="OptionMetadata.Prefix"/> 
-        /// that matches the specified <paramref name="typeName"/>.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> that contains the name of the type of the metadata.</param>
-        /// <returns>An <see cref="OptionMetadata"/> object; or null if none match.</returns>
-        private OptionMetadata? GetOptionMetadata(string typeName) =>
-            this.options.OptionMetadata
-                .FirstOrDefault(metadata => metadata.Prefix == typeName);
 
         #endregion
     }

--- a/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
@@ -18,19 +18,14 @@ namespace Crowswood.CsvConverter.Helpers
         /// <param name="properties">A <see cref="PropertyInfo"/> array.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
         internal static IEnumerable<string> AsStrings<TBase>(TBase item, PropertyInfo[] properties)
-            where TBase : class
-        {
-            var results = new List<string>();
-
-            foreach (var property in properties)
-            {
-                var value = property.GetValue(item)?.ToString();
-                var text = GetText(property.PropertyType, value);
-                results.Add(text);
-            }
-
-            return results;
-        }
+            where TBase : class =>
+            properties
+                .Select(property => new 
+                {
+                    Type = property.PropertyType,
+                    Value = property.GetValue(item),
+                })
+                .Select(item => GetText(item.Type, item.Value?.ToString()));
 
         /// <summary>
         /// Format the specified <paramref name="prefix"/>, <paramref name="typeName"/> and 

--- a/Crowswood.CsvConverter/Helpers/OptionsHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/OptionsHelper.cs
@@ -25,11 +25,27 @@
                     "The metadata prefix must be different to that of the property prefix and values prefix.",
                     nameof(options));
 
-            if (options.OptionMetadata
-                    .Where(om => om is not OptionMetadataDictionary)
-                    .Select(om => new { OptionsMetadata = om, Properties = om.Type.GetProperties(), })
-                    .Select(n => new { n.OptionsMetadata, PropertyNames = n.Properties.Select(p => p.Name).ToList(), })
-                    .Any(n => n.OptionsMetadata.PropertyNames.Any(pn => !n.PropertyNames.Contains(pn))))
+            var typedMetadataProperties =
+                options.OptionMetadata
+                    .Where(om => om is not OptionTypelessMetadata)
+                    .Select(om => new 
+                    {
+                        OptionsMetadata = om,
+                        Properties = om.Type.GetProperties(),
+                    })
+                    .Select(n => new 
+                    {
+                        n.OptionsMetadata,
+                        PropertyNames = 
+                            n.Properties
+                                .Select(p => p.Name)
+                                .ToList(),
+                    })
+                    .ToList();
+            if (typedMetadataProperties
+                    .Any(n => 
+                        n.OptionsMetadata.PropertyNames
+                            .Any(pn => !n.PropertyNames.Contains(pn))))
                 throw new ArgumentException(
                     "The metadata may only contain property names defined by the targeted type.",
                     nameof(options));

--- a/Crowswood.CsvConverter/Interfaces/ISerialization.cs
+++ b/Crowswood.CsvConverter/Interfaces/ISerialization.cs
@@ -1,0 +1,113 @@
+﻿namespace Crowswood.CsvConverter.Interfaces
+{
+    public interface ISerialization
+    {
+        /// <summary>
+        /// Gets the converter that will be handling the conversion.
+        /// </summary>
+        Converter Converter { get; }
+
+        /// <summary>
+        /// Specifies the <paramref name="globalConfiguration"/> to include in the serialization.
+        /// </summary>
+        /// <param name="globalConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the global configuration.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization GlobalConfig(Dictionary<string, string> globalConfiguration);
+
+        /// <summary>
+        /// Specifies the <paramref name="typeConfiguration"/> to include in the serialization.
+        /// </summary>
+        /// <typeparam name="TObject">The type to associate with this type configuration.</typeparam>
+        /// <param name="typeConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type configuration.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypeConfig<TObject>(Dictionary<string, string> typeConfiguration);
+
+        /// <summary>
+        /// Specifies the number of blank lines to include in the serialization.
+        /// </summary>
+        /// <param name="number">An <see cref="int"/> that contains the number of blank lines to include; defaults to one.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization BlankLine(int number = 1);
+
+        /// <summary>
+        /// Specifies the <paramref name="typeConversion"/> to include in the serialization.
+        /// </summary>
+        /// <param name="typeConversion">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type conversion.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypeConversion(Dictionary<string, string> typeConversion);
+
+        /// <summary>
+        /// Specifies the <paramref name="valueConversion"/> to include in the serialization.
+        /// </summary>
+        /// <param name="valueConversion">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the value conversion.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization ValueConversion(Dictionary<string, string> valueConversion);
+
+        /// <summary>
+        /// Specifies the <paramref name="comment"/> and the <paramref name="commentPrefix"/> to 
+        /// include in the serialization.
+        /// </summary>
+        /// <param name="commentPrefix">A <see cref="string"/> that contains the comment prefix; it must correspond to one of the defined comment prefixes.</param>
+        /// <param name="comment">A <see cref="string"/> that contains the text of the comment.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization Comment(string commentPrefix, string comment);
+
+        /// <summary>
+        /// Specifies the <paramref name="metadata"/> for <typeparamref name="TObject"/> to 
+        /// include in the serialization.
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object that the metadata describes.</typeparam>
+        /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <typeparamref name="TMetadata"/> that contains the metadata.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypedMetadata<TObject, TMetadata>(IEnumerable<TMetadata> metadata)
+            where TObject : class
+            where TMetadata : class;
+
+        /// <summary>
+        /// Specifies the <paramref name="metadata"/> that has the specified <paramref name="metadataTypeName"/> 
+        /// to include in the serialization.
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object that the metadata describes.</typeparam>
+        /// <param name="metadataTypeName">A <see cref="string"/> that contains the type name of the metadata.</param>
+        /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the property name that contains the metadata.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypelessMetadata<TObject>(string metadataTypeName, Dictionary<string, string> metadata) =>
+            TypelessMetadata(typeof(TObject).Name, metadataTypeName, metadata);
+
+        /// <summary>
+        /// Specifies the <paramref name="metadata"/> that has the specified <paramref name="metadataPrefix"/> 
+        /// for the specified <paramref name="typeName"/> to include in the serialization.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> that contains the type name of the object that the metadata describes.</param>
+        /// <param name="metadataPrefix">A <see cref="string"/> that contains the prefix of the metadata.</param>
+        /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the property name that contains the metadata.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypelessMetadata(string typeName, string metadataPrefix, Dictionary<string,string> metadata);
+
+        /// <summary>
+        /// Specifies the <paramref name="data"/> to include in the serialization.
+        /// </summary>
+        /// <typeparam name="Tobject">The type of the data.</typeparam>
+        /// <param name="data">An <see cref="IEnumerable{T}"/> of <typeparamref name="Tobject"/> that contains the data.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypedData<Tobject>(IEnumerable<Tobject> data)
+            where Tobject : class;
+
+        /// <summary>
+        /// Specifies the <paramref name="data"/> for the specified <paramref name="typeName"/> to 
+        /// include in the serialization.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> that contains the type name of the data.</param>
+        /// <param name="names">A <see cref="string[]"/> that contains the property names of the data.</param>
+        /// <param name="values">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> containing the values of the data.</param>
+        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        public ISerialization TypelessData(string typeName, string[] names, IEnumerable<string[]> values);
+
+        /// <summary>
+        /// Serializes the previously specified data.
+        /// </summary>
+        /// <returns>A <see cref="string"/> containing the serialized data.</returns>
+        public string Serialize();
+    }
+}

--- a/Crowswood.CsvConverter/Options/OptionMetadata.cs
+++ b/Crowswood.CsvConverter/Options/OptionMetadata.cs
@@ -51,10 +51,9 @@
     /// been configured.
     /// </summary>
     /// <typeparam name="T">The type of object to be created.</typeparam>
-    public sealed class OptionMetadata<T> : OptionMetadata
+    public sealed class OptionTypedMetadata<T> : OptionMetadata
         where T : class, new()
     {
-
         #region Properties
 
         /// <inheritdoc/>
@@ -64,7 +63,7 @@
 
         #region Constructors
 
-        public OptionMetadata(string prefix, params string[] propertyNames)
+        public OptionTypedMetadata(string prefix, params string[] propertyNames)
             : base(prefix, propertyNames) { }
 
         #endregion
@@ -78,11 +77,11 @@
     }
 
     /// <summary>
-    /// A sealed class that indicates that the metadata is a <see cref="Dictionary{TKey, TValue}"/>
-    /// of <see cref="string"/> keyed by <see cref="string"/>; the value may be nullable depending
+    /// A sealed class that indicates that the metadata is typeless and contains information about 
+    /// a specific type of metadata that has been configured; the value may be nullable depending
     /// on <seealso cref="AllowNulls"/>.
     /// </summary>
-    public sealed class OptionMetadataDictionary : OptionMetadata
+    public sealed class OptionTypelessMetadata : OptionMetadata
     {
         #region Properties
 
@@ -101,7 +100,7 @@
 
         #region Constructors
 
-        public OptionMetadataDictionary(string prefix, params string[] propertyNames)
+        public OptionTypelessMetadata(string prefix, params string[] propertyNames)
             : base(prefix, propertyNames) { }
 
         #endregion

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -143,19 +143,19 @@ namespace Crowswood.CsvConverter
 
 
         /// <summary>
-        /// Adds a new <see cref="OptionMetadata{T}"/> for the specified <paramref name="prefix"/>
+        /// Adds a new <see cref="OptionTypedMetadata{T}"/> for the specified <paramref name="prefix"/>
         /// and <paramref name="propertyNames"/>
         /// </summary>
-        /// <typeparam name="TMetadata">The generic parameter of the <see cref="OptionMetadata{T}"/>.</typeparam>
+        /// <typeparam name="TMetadata">The generic parameter of the <see cref="OptionTypedMetadata{T}"/>.</typeparam>
         /// <param name="prefix">A <see cref="string"/> that contains the prefix.</param>
         /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
         /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
         public Options ForMetadata<TMetadata>(string prefix, params string[] propertyNames)
             where TMetadata : class, new() =>
-            AddMetadata(new OptionMetadata<TMetadata>(prefix, propertyNames));
+            AddMetadata(new OptionTypedMetadata<TMetadata>(prefix, propertyNames));
 
         /// <summary>
-        /// Adds a new <see cref="OptionMetadataDictionary"/> for the specific <paramref name="prefix"/>
+        /// Adds a new <see cref="OptionTypelessMetadata"/> for the specific <paramref name="prefix"/>
         /// and <paramref name="propertyNames"/> with nulls being allowed or not through 
         /// <paramref name="allowNulls"/>.
         /// </summary>
@@ -163,8 +163,8 @@ namespace Crowswood.CsvConverter
         /// <param name="allowNulls">True if null values are allowed; false otherwise.</param>
         /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
         /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
-        public Options ForMetadata(string prefix, bool allowNulls,params string[] propertyNames)=>
-            AddMetadata(new OptionMetadataDictionary(prefix, propertyNames) 
+        public Options ForMetadata(string prefix, bool allowNulls, params string[] propertyNames) =>
+            AddMetadata(new OptionTypelessMetadata(prefix, propertyNames) 
             {
                 AllowNulls = allowNulls
             });

--- a/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
+++ b/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
@@ -10,7 +10,6 @@ namespace Crowswood.CsvConverter.Processors
         #region Fields
 
         private readonly Options options;
-
         private readonly MetadataHandler metadataHandler;
 
         #endregion
@@ -20,7 +19,6 @@ namespace Crowswood.CsvConverter.Processors
         public SerializationProcessor(Options options, MetadataHandler metadataHandler)
         {
             this.options = options;
-
             this.metadataHandler = metadataHandler;
         }
 
@@ -34,7 +32,7 @@ namespace Crowswood.CsvConverter.Processors
         /// <typeparam name="TBase">The base type of objects to serialize.</typeparam>
         /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> to serialize.</param>
         /// <returns>A <see cref="string"/>.</returns>
-        internal string Process<T>(params T[] values) where T : class
+        internal string Process<TBase>(params TBase[] values) where TBase : class
         {
             var lines = new List<string>();
 
@@ -45,10 +43,10 @@ namespace Crowswood.CsvConverter.Processors
             foreach (var type in types)
             {
                 lines.AddRange(ConvertFrom(type, values));
-                lines.Add("\r\n");
+                lines.Add(Environment.NewLine);
             }
 
-            var text = string.Join("\r\n", lines);
+            var text = string.Join(Environment.NewLine, lines);
             return text;
         }
 
@@ -59,63 +57,17 @@ namespace Crowswood.CsvConverter.Processors
         /// <returns>A <see cref="string"/>.</returns>
         internal string Process(Dictionary<string, (string[], IEnumerable<string[]>)> data)
         {
-            var lines = new List<string>();
+            var lines =
+                data.Select(kvp => Process(kvp.Key, kvp.Value.Item1, kvp.Value.Item2))
+                    .SelectMany(item => item);
 
-            foreach (var kvp in data)
-            {
-                if (this.metadataHandler.Metadata.ContainsKey(kvp.Key))
-                {
-                    lines.AddRange(
-                        this.metadataHandler.Metadata[kvp.Key]
-                            .Select(item => new
-                            {
-                                Prefix =
-                                    this.options.OptionMetadata
-                                        .Where(optionsMetadata => optionsMetadata.Type == item.GetType())
-                                        .Select(optionsMetadata => optionsMetadata.Prefix)
-                                        .FirstOrDefault(),
-                                Item = item,
-                            })
-                            .Where(n => n.Prefix is not null)
-                            .Select(n => new
-                            {
-                                n.Prefix,
-                                Values =
-                                    n.Item.GetType().GetProperties()
-                                        .Select(property => property.GetValue(n.Item)?.ToString())
-                                        .Select(value => value is null ? string.Empty : $"\"{value}\"")
-                                        .ToArray(),
-                            })
-                            .Select(n => ConverterHelper.FormatCsvData(n.Prefix!, kvp.Key, n.Values)));
-                }
-                lines.Add(ConverterHelper.FormatCsvData(this.options.PropertyPrefix, kvp.Key, kvp.Value.Item1)); //  Serialize
-                lines.AddRange(
-                    kvp.Value.Item2
-                        .Select(items => ConverterHelper.FormatCsvData(this.options.ValuesPrefix, kvp.Key, items.Select(n => $"\"{n}\"").ToArray())));
-                lines.Add("\r\n");
-            }
-
-            var text = string.Join("\r\n", lines);
+            var text = string.Join(Environment.NewLine, lines);
             return text;
         }
 
         #endregion
 
         #region Conversion routines
-
-        /// <summary>
-        /// Converts the specified <paramref name="values"/> according to the <paramref name="optionType"/>
-        /// into an <see cref="IEnumerable{T}"/> of <see cref="string"/>.
-        /// </summary>
-        /// <typeparam name="TBase">The type of object to process.</typeparam>
-        /// <param name="optionType">An <see cref="OptionType"/> that controls the conversion.</param>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="TBase"/> that contains the objects to process.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        /// <exception cref="ArgumentException">If <seealso cref="OptionType.Type"/> cannot be assigned to <typeparamref name="TBase"/>.</exception>
-        /// <exception cref="InvalidOperationException">If the conversion failed.</exception>
-        private IEnumerable<string> ConvertFrom<TBase>(OptionType optionType, IEnumerable<TBase> values)
-            where TBase : class =>  //  can't use a new() contraint as TBase may well be abstract
-            ConvertFrom<TBase>(optionType.Type, values);
 
         /// <summary>
         /// Converts the specified <paramref name="values"/> of type <paramref name="type"/> into
@@ -135,92 +87,149 @@ namespace Crowswood.CsvConverter.Processors
                 throw new ArgumentException(
                     $"Unable to assign an object of type {type.Name} to {typeof(TBase).Name}.");
 
-            var name = nameof(ConvertFrom);
+            var properties = GetProperties(type);
+            var parameters = GetParameters(properties);
+            var typeName = GetTypeName(type);
 
-            var returnType = typeof(IEnumerable<>).MakeGenericType(typeof(string));
-
-            // Filter the parameters to those just of the type we're currently working with.
-            var parameters = new object[]
-                {
-                    values
-                        .Where(n => n?.GetType().Equals(type) ?? false)
-                        .ToList(),
-                    type,
-                };
-
-            // Explicitly set the types, rather than relying on the type of each parameter.
-            var types =
-                new[]
-                {
-                    typeof(IEnumerable<>).MakeGenericType(typeof(TBase)),
-                    typeof(Type),
-                };
-
-            // name is the name of the method to retrieve.
-            // type is the generic type parameter.
-            // returnType is the type of the return parameter.
-            // types are the types of the parameters the method expects.
-            var method = GetType().GetGenericMethod(name, typeof(TBase), returnType, types);
-            var result =
-                method.Invoke(this, parameters) ??
-                throw new InvalidOperationException(
-                    $"Failed to convert from type {type.Name}.");
-
-            return (IEnumerable<string>)result;
-        }
-
-        /// <summary>
-        /// Converts the specified <paramref name="values"/> into an <see cref="IEnumerable{T}"/> 
-        /// of <see cref="string"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of object to process.</typeparam>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/> that contains the objects to process.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        /// <remarks>This routine is called by reflection.</remarks>
-        private IEnumerable<string> ConvertFrom<T>(IEnumerable<T> values, Type type)
-            where T : class //  can't use a new() contraint as TBase may well be abstract
-        {
-            var results = new List<string>();
-
-            var properties =
-                type.GetProperties()
-                    .Where(property => property.CanRead)
-                    .Where(property => property.CanWrite)
-                    .Where(property => property.PropertyType == typeof(string) ||
-                                       property.PropertyType.IsValueType &&
-                                       property.PropertyType != typeof(DateTime))
-                    .Select(property => new
-                    {
-                        Property = property,
-                        Depth = property.DeclaringType?.GetDepth() ?? 0,
-                    })
-                    .OrderBy(n => n.Depth)
-                    .Select(n => n.Property)
-                    .ToArray();
-            var parameters =
-                properties
-                    .Select(property =>
-                        this.options.OptionMembers
-                            .Where(assignment => assignment.Property.Name == property.Name)
-                            .Select(assignment => assignment.Name)
-                            .FirstOrDefault() ??
-                        property.GetCustomAttribute<CsvConverterPropertyAttribute>()?.Name ??
-                        property.Name)
-                    .ToArray();
-
-            var typeName =
-                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-                type.Name;
-
-            results.Add(ConverterHelper.FormatCsvData(this.options.PropertyPrefix, typeName, parameters)); //  ConvertFrom
-            foreach (var value in values)
-            {
-                var asStrings = ConverterHelper.AsStrings(value, properties);
-                results.Add(ConverterHelper.FormatCsvData(this.options.ValuesPrefix, typeName, asStrings.ToArray()));
-            }
+            var results =
+                values
+                    .NotNull()
+                    .Where(value => value.GetType().Equals(type))
+                    .Select(value => ConverterHelper.AsStrings(value, properties).ToArray())
+                    .Select(value => ConverterHelper.FormatCsvData(this.options.ValuesPrefix, typeName, value))
+                    .ToList();
+            results.Insert(0,
+                ConverterHelper.FormatCsvData(this.options.PropertyPrefix, typeName, parameters));
 
             return results;
         }
+
+        #endregion
+
+        #region Support routines
+
+        /// <summary>
+        /// Gets the public read/write properties that are supported for serialization for the 
+        /// specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="PropertyInfo"/> array.</returns>
+        private static PropertyInfo[] GetProperties(Type type) =>
+            type.GetProperties()
+                .Where(property => property.CanRead)
+                .Where(property => property.CanWrite)
+                .Where(property => property.PropertyType == typeof(string) ||
+                                   property.PropertyType.IsValueType &&
+                                   property.PropertyType != typeof(DateTime))
+                .Select(property => new { Property = property, Depth = property.GetTypeDepth(), })
+                .OrderBy(n => n.Depth)
+                .Select(n => n.Property)
+                .ToArray();
+
+        /// <summary>
+        /// Gets the property names from the specified <paramref name="properties"/> with any 
+        /// conversions that are defined in the <seealso cref="options"/> or as an attribute on 
+        /// the member itself.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/> that contains the properties.</param>
+        /// <returns>A <see cref="string[]"/> containing the names.</returns>
+        private string[] GetParameters(PropertyInfo[] properties) =>
+            properties
+                .Select(property =>
+                    this.options.GetOptionMember(property)?.Name ??
+                    property.GetCustomAttribute<CsvConverterPropertyAttribute>()?.Name ??
+                    property.Name)
+                .ToArray();
+
+        /// <summary>
+        /// Gets the type name for the specified <paramref name="type"/> with any conversion that 
+        /// is defined in the <seealso cref="options"/> or as an attribute on the type itself.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to get the name of.</param>
+        /// <returns>A <see cref="string"/> containing the type name.</returns>
+        private string GetTypeName(Type type) =>
+            this.options.GetOptionType(type)?.Name ??
+            type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+            type.Name;
+
+        /// <summary>
+        /// Serializes the specified <paramref name="typeName"/> with the specified <paramref name="propertyNames"/> 
+        /// and <paramref name="dataValues"/> including any metadata.
+        /// </summary>
+        /// <param name="typeName">A <see cref="string"/> containing the name of the data type.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the names of the properties.</param>
+        /// <param name="dataValues">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> containing the data values.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="string"/>.</returns>
+        private List<string> Process(string typeName, string[] propertyNames, IEnumerable<string[]> dataValues)
+        {
+            List<string> results = new();
+
+            // If there is any metadata for this type then add that first.
+            if (this.metadataHandler.Metadata.TryGetValue(typeName, out var metadataItems))
+            {
+                var metadataValues =
+                    metadataItems
+                        .Select(item => new
+                        {
+                            Metadata = this.options.GetOptionMetadata(item.GetType()),
+                            Item = item,
+                        })
+                        .Where(n => n.Metadata?.Prefix is not null)
+                        .Select(n => new
+                        {
+                            n.Metadata!.Prefix,
+                            Values = GetValues(n.Item, n.Metadata),
+                        })
+                        .Select(n => ConverterHelper.FormatCsvData(n.Prefix, typeName, n.Values));
+                results.AddRange(metadataValues);
+            }
+
+            // Add the properties line.
+            results.Add(
+                ConverterHelper.FormatCsvData(this.options.PropertyPrefix,
+                                              typeName,
+                                              propertyNames));
+
+            // Finally add all the values lines.
+            results.AddRange(
+                dataValues
+                    .Select(items => items.Select(item => $"\"{item}\"").ToArray())
+                    .Select(values => ConverterHelper.FormatCsvData(this.options.ValuesPrefix,
+                                                                    typeName,
+                                                                    values)));
+
+            // Add a blank line to separate the block of data for this type from any others.
+            results.Add(Environment.NewLine);
+
+            return results;
+        }
+
+        /// <summary>
+        /// Gets the values of the properties from the specified <paramref name="item"/> as 
+        /// defined in the specified <paramref name="optionMetadata"/> as a <see cref="string[]"/> 
+        /// including adding leading and trailing double-quote marks.
+        /// </summary>
+        /// <param name="item">An <see cref="object"/>.</param>
+        /// <param name="optionMetadata">A <see cref="OptionMetadata"/> object.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetValues(object item, OptionMetadata optionMetadata) =>
+            GetValues(item, optionMetadata.PropertyNames, item.GetType().GetProperties());
+
+        /// <summary>
+        /// Gets the values of the properties from the specified <paramref name="item"/> using 
+        /// the specified <paramref name="properties"/> that are named in the specified <paramref name="propertyNames"/>.
+        /// as a <see cref="string[]"/> including adding leading and trailing double-quote marks.
+        /// </summary>
+        /// <param name="item">An <see cref="object"/>.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the names of the properties that are to be included.</param>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/> containing the properties to retrieve.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetValues(object item, string[] propertyNames, PropertyInfo[] properties) =>
+            propertyNames
+                .Select(propertyName => properties.FirstOrDefault(property => property.Name == propertyName))
+                .Select(property => property?.GetValue(item)?.ToString() ?? string.Empty)
+                .Select(value => $"\"{value}\"")
+                .ToArray();
 
         #endregion
     }

--- a/Crowswood.CsvConverter/Serialization.cs
+++ b/Crowswood.CsvConverter/Serialization.cs
@@ -1,0 +1,620 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Interfaces;
+
+namespace Crowswood.CsvConverter
+{
+    /// <summary>
+    /// An internal class to manage the serialization of data using a fluent interface.
+    /// </summary>
+    internal class Serialization :
+        ISerialization
+    {
+        #region Fields
+
+        private readonly List<BaseSerializationData> serializations = new();
+
+        private readonly ConfigHandler configHandler;
+
+        #endregion
+
+        #region Properties
+
+        public Converter Converter { get; }
+        public Options Options { get; }
+
+        #endregion
+
+        #region Constructors
+
+        internal Serialization(Converter converter, Options options)
+        {
+            this.Converter = converter;
+            this.Options = options;
+
+            this.configHandler = new ConfigHandler(this.Options);
+        }
+
+        #endregion
+
+        #region Interface methods
+
+        /// <inheritdoc/>
+        public ISerialization GlobalConfig(Dictionary<string, string> globalConfiguration)
+        {
+            this.serializations.Add(
+                new GlobalConfigData(globalConfiguration));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
+        {
+            this.serializations.Add(
+                new TypedConfigData(typeof(TObject).Name, typeConfiguration));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization BlankLine(int number = 1)
+        {
+            this.serializations.Add(
+                new BlankLinesData(number));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypeConversion(Dictionary<string, string> typeConversion)
+        {
+            this.serializations.Add(
+                new TypeConversionData(typeConversion));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization ValueConversion(Dictionary<string, string> valueConversion)
+        {
+            this.serializations.Add(
+                new ValueConversionData(valueConversion));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization Comment(string commentPrefix, string comment)
+        {
+            this.serializations.Add(
+                new CommentData(commentPrefix, comment));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypedMetadata<TObject, TMetadata>(IEnumerable<TMetadata> metadata)
+            where TObject : class
+            where TMetadata : class
+        {
+            var metadataType = typeof(TMetadata);
+
+            var optionMetadata =
+                this.Options.GetOptionMetadata(metadataType) ?? 
+                throw new InvalidOperationException(
+                    $"No Metadata definition in Options for '{metadataType.Name}'.");
+
+            this.serializations.Add(
+                new TypedMetadataData<TObject, TMetadata>(optionMetadata.Prefix,
+                                                          optionMetadata.PropertyNames,
+                                                          metadata));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypelessMetadata(string typeName, string metadataPrefix, Dictionary<string, string> metadata)
+        {
+            var optionMetadata =
+                this.Options.GetOptionMetadata(metadataPrefix) ?? 
+                throw new InvalidOperationException(
+                    $"No Metadata definition in Options for metadata with a prefix of '{metadataPrefix}'.");
+
+            this.serializations.Add(
+                new TypelessMetadataData(typeName,
+                                         optionMetadata.Prefix,
+                                         optionMetadata.PropertyNames,
+                                         metadata));
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypedData<Tobject>(IEnumerable<Tobject> data)
+            where Tobject : class
+        {
+            var type = typeof(Tobject);
+            var typeName =
+                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+                type.Name;
+            var propertyPrefix =
+                this.configHandler.GetPropertyPrefix(typeName);
+            var valuePrefix =
+                this.configHandler.GetValuePrefix(typeName);
+
+            this.serializations.Add(
+                new TypedDataData<Tobject>(propertyPrefix, valuePrefix, typeName, data));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISerialization TypelessData(string typeName, string[] names, IEnumerable<string[]> values)
+        {
+            var propertyPrefix =
+                this.configHandler.GetPropertyPrefix(typeName);
+            var valuePrefix =
+                this.configHandler.GetValuePrefix(typeName);
+
+            this.serializations.Add(new TypelessDataData(propertyPrefix, valuePrefix, typeName, names, values));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public string Serialize()
+        {
+            List<string> list = new();
+
+            foreach (var serialization in this.serializations)
+                list.AddRange(serialization.Serialize());
+
+            var text = string.Join(Environment.NewLine, list);
+            return text;
+        }
+
+        #endregion
+
+        #region Nested classes
+
+        /// <summary>
+        /// The abstract base class for holding data to be serialized.
+        /// </summary>
+        private abstract class BaseSerializationData
+        {
+            /// <summary>
+            /// Serialize the data held in the current instance.
+            /// </summary>
+            /// <returns>A <see cref="string"/> containing the result of the serialization.</returns>
+            public abstract string[] Serialize();
+        }
+
+        /// <summary>
+        /// A sealed class for holding blank line data.
+        /// </summary>
+        private sealed class BlankLinesData : BaseSerializationData
+        {
+            private readonly int number;
+
+            public BlankLinesData(int number) => this.number = number;
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                Enumerable
+                    .Range(0, this.number)
+                    .Select(_ => string.Empty)
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// A sealed class for serializing comments.
+        /// </summary>
+        private sealed class CommentData : BaseSerializationData
+        {
+            private readonly string prefix;
+            private readonly string[] comments;
+
+            public CommentData(string prefix, params string[] comments)
+            {
+                this.prefix = prefix;
+                this.comments =
+                    comments
+                        // Split using `\r\n` CharArray rather than `Environment.NewLine` to cater
+                        // for files that use a differnet standard from the current OS.
+                        // Don't trim the resultant comments to allow them to have leading spaces.
+                        .Select(comment => comment.Split("\r\n".ToCharArray(),
+                                                         StringSplitOptions.RemoveEmptyEntries))
+                        .SelectMany(comment => comment)
+                        .ToArray();
+            }
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                this.comments
+                    .Select(comment => $"{prefix} {comment}")
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// An abstract base class for serializing config data.
+        /// </summary>
+        private abstract class BaseConfigData : BaseSerializationData
+        {
+            protected Dictionary<string, string> Configuration { get; }
+
+            protected abstract Lazy<string[]> ValidKeys { get; }
+
+            protected BaseConfigData(Dictionary<string, string> configuration) =>
+                this.Configuration = configuration;
+
+            protected IEnumerable<KeyValuePair<string, string>> GetConfiguration() =>
+                this.Configuration
+                    .Where(kvp => this.ValidKeys.Value.Any(key => key == kvp.Key));
+
+            protected static string[] GetValidKeys(Type type) =>
+                type.GetFields(BindingFlags.Public |
+                                BindingFlags.Static)
+                    .Where(field => field.FieldType == typeof(string))
+                    .Select(field => field.GetValue(null))
+                    .Cast<string>()
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// A sealed class for serializing global config data.
+        /// </summary>
+        private sealed class GlobalConfigData : BaseConfigData
+        {
+            private readonly string prefix = Converter.Keys.GlobalConfig.GlobalConfigPrefix;
+
+            protected override Lazy<string[]> ValidKeys { get; } =
+                new(() => GetValidKeys(typeof(Converter.Keys.GlobalConfig)));
+
+            public GlobalConfigData(Dictionary<string, string> configuration)
+                : base(configuration) { }
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                GetConfiguration()
+                    .Select(kvp => $"{this.prefix},{kvp.Key},{kvp.Value}")
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// A sealed class for serializing typed config data.
+        /// </summary>
+        private sealed class TypedConfigData : BaseConfigData
+        {
+            private readonly string prefix = Converter.Keys.TypedConfig.TypedConfigPrefix;
+            private readonly string typeName;
+
+            protected override Lazy<string[]> ValidKeys { get; } =
+                new(() => GetValidKeys(typeof(Converter.Keys.TypedConfig)));
+
+            public TypedConfigData(string typeName, Dictionary<string, string> configuration)
+                : base(configuration) => this.typeName = typeName;
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                GetConfiguration()
+                    .Select(kvp => $"{this.prefix},{this.typeName},{kvp.Key},{kvp.Value}")
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// An abstract base class for serializing conversion data.
+        /// </summary>
+        private abstract class BaseConversionData : BaseSerializationData
+        {
+            private readonly string prefix;
+            private readonly Dictionary<string, string> conversion;
+
+            protected BaseConversionData(string prefix, Dictionary<string, string> conversion)
+            {
+                this.prefix = prefix;
+                this.conversion = conversion;
+            }
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                this.conversion
+                    .Select(kvp => $"{this.prefix},\"{kvp.Key}\",\"{kvp.Value}\"")
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// A sealed class for serializing type conversion data.
+        /// </summary>
+        private sealed class TypeConversionData : BaseConversionData
+        {
+            public TypeConversionData(Dictionary<string, string> typeConversion)
+                : base(ConfigHandler.Configurations.ConversionTypePrefix, typeConversion) { }
+        }
+
+        /// <summary>
+        /// A sealed class for serializing value conversion data.
+        /// </summary>
+        private sealed class ValueConversionData : BaseConversionData
+        {
+            public ValueConversionData(Dictionary<string, string> valueConversion)
+                : base(ConfigHandler.Configurations.ConversionValuePrefix, valueConversion) { }
+        }
+
+        /// <summary>
+        /// An abstract base class for serializing metadata.
+        /// </summary>
+        private abstract class BaseMetadataData : BaseSerializationData
+        {
+            protected readonly string typeName;
+            protected readonly string metadataPrefix;
+            protected readonly string[]? propertyNames;
+
+            protected BaseMetadataData(string typeName, string metadataPrefix, string[]? propertyNames)
+            {
+                this.typeName = typeName;
+                this.metadataPrefix = metadataPrefix;
+                this.propertyNames = propertyNames;
+            }
+        }
+
+        /// <summary>
+        /// A sealed class for serializing typed metadata of <typeparamref name="TMetadata"/> for 
+        /// a <typeparamref name="TObject"/>.
+        /// </summary>
+        /// <typeparam name="TObject">The type of object that the metadata is applied to.</typeparam>
+        /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
+        private sealed class TypedMetadataData<TObject, TMetadata> : BaseMetadataData
+            where TObject : class
+            where TMetadata : class
+        {
+            private readonly IEnumerable<TMetadata> metadata;
+            private readonly PropertyInfo[] properties;
+
+            public TypedMetadataData(string prefix, string[]? propertyNames, IEnumerable<TMetadata> metadata)
+                : base(typeof(TObject).Name, prefix, propertyNames)
+            {
+                this.metadata = metadata;
+
+                this.properties =
+                    typeof(TMetadata).GetProperties(BindingFlags.Instance |
+                                                    BindingFlags.Public)
+                        .Where(property => property.CanRead && property.CanWrite)
+                        .Where(property => this.propertyNames?.Contains(property.Name) ?? false)
+                        .ToArray();
+            }
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                this.metadata
+                    .Select(md => GetValues(md))
+                    .Where(values => !string.IsNullOrWhiteSpace(values))
+                    .Select(values => $"{this.metadataPrefix},{this.typeName},{values}")
+                    .ToArray();
+
+            private string GetValues(TMetadata metadata)
+            {
+                if (this.propertyNames is null)
+                    return string.Empty;
+
+                // The values must be in the order defined in the Options Metadata,
+                // so derive them from the Options Metadata PropertyNames,
+                // rather than directly from the properties of the Type.
+
+                var properties =
+                    this.propertyNames
+                        .Select(propertyName =>
+                            this.properties
+                                .FirstOrDefault(property => property.Name == propertyName))
+                        .NotNull()
+                        .ToArray();
+                if (properties is null)
+                    return string.Empty;
+
+                var results =
+                    ConverterHelper.AsStrings(metadata, properties)
+                        .ToArray();
+
+                var result = string.Join(",", results);
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// A sealed class for serializing typeless metadata.
+        /// </summary>
+        private sealed class TypelessMetadataData : BaseMetadataData
+        {
+            private readonly Dictionary<string, string> metadata;
+
+            public TypelessMetadataData(string typeName, string metadataPrefix, string[]? propertyNames, Dictionary<string, string> metadata)
+                : base(typeName, metadataPrefix, propertyNames) => this.metadata = metadata;
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                new[] { $"{this.metadataPrefix},{this.typeName},{GetValues()}" };
+
+            private string GetValues()
+            {
+                var results = this.propertyNames is null ?
+                    Array.Empty<string>() :
+                    this.propertyNames
+                        .Select(propertyName =>
+                            this.metadata.TryGetValue(propertyName, out var value)
+                                ? value
+                                : string.Empty)
+                        .Select(value => $"\"{value}\"")
+                        .ToArray();
+
+                var result = string.Join(",", results);
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// An abstract base class for serializing data.
+        /// </summary>
+        private abstract class BaseDataData : BaseSerializationData
+        {
+            #region Fields
+
+            protected readonly string propertyPrefix;
+            protected readonly string valuePrefix;
+            protected readonly string typeName;
+
+            #endregion
+
+            #region Abstract properties
+
+            protected abstract string[] Names { get; }
+
+            #endregion
+
+            #region Constructors
+
+            protected BaseDataData(string propertyPrefix, string valuePrefix, string typeName)
+            {
+                this.propertyPrefix = propertyPrefix;
+                this.valuePrefix = valuePrefix;
+                this.typeName = typeName;
+            }
+
+            #endregion
+
+            #region Overrides
+
+            /// <inheritdoc/>
+            public override string[] Serialize() =>
+                GetNames()
+                    .Union(GetValues())
+                    .ToArray();
+
+            #endregion
+
+            #region Abstract support routines
+
+            protected abstract string[] GetValues();
+
+            #endregion
+
+            #region Support routines
+
+            private string[] GetNames() =>
+                new[] { ConverterHelper.FormatCsvData(this.propertyPrefix, this.typeName, this.Names), };
+
+            #endregion
+        }
+
+        /// <summary>
+        /// A sealed class for serializing data of <typeparamref name="TObject"/>.
+        /// </summary>
+        /// <typeparam name="TObject">The type of the data.</typeparam>
+        private sealed class TypedDataData<TObject> : BaseDataData
+            where TObject : class
+        {
+            #region Fields
+
+            private readonly IEnumerable<TObject> data;
+            private readonly PropertyInfo[]? properties;
+            private readonly string[] names;
+
+            #endregion
+
+            #region Override properties
+
+            protected override string[] Names => this.names;
+
+            #endregion
+
+            #region Constructors
+
+            public TypedDataData(string propertyPrefix, string valuePrefix, string typeName, IEnumerable<TObject> data)
+                : base(propertyPrefix, valuePrefix, typeName)
+            {
+                this.data = data;
+                this.properties =
+                    typeof(TObject).GetProperties(BindingFlags.Instance |
+                                                  BindingFlags.Public)
+                        .Where(property => property.CanRead && property.CanWrite)
+                        .ToArray();
+                this.names = GetNames();
+            }
+
+            #endregion
+
+            #region Overrides
+
+            protected override string[] GetValues() =>
+                this.data
+                    .Select(item => GetValues(item))
+                    .Where(values => values.Any())
+                    .Where(values => values.Length == this.names.Length)
+                    .Select(values => ConverterHelper.FormatCsvData(this.valuePrefix, this.typeName, values))
+                    .ToArray();
+
+            #endregion
+
+            #region Support routines
+
+            private string[] GetNames() =>
+                this.properties is null ?
+                    Array.Empty<string>() :
+                    this.properties
+                        .Select(property => property.Name)
+                        .ToArray();
+
+            private string[] GetValues(TObject item) =>
+                this.properties is null ?
+                    Array.Empty<string>() :
+                    ConverterHelper.AsStrings(item, this.properties)
+                        .ToArray();
+
+            #endregion
+        }
+
+        /// <summary>
+        /// A sealed class for serializing typeless data.
+        /// </summary>
+        private sealed class TypelessDataData : BaseDataData
+        {
+            #region Fields
+
+            private readonly IEnumerable<string[]> values;
+
+            #endregion
+
+            #region Override properties
+
+            protected override string[] Names { get; }
+
+            #endregion
+
+            #region Constructors
+
+            public TypelessDataData(string propertyPrefix, string valuePrefix, string typeName, string[] names, IEnumerable<string[]> values)
+                : base(propertyPrefix, valuePrefix, typeName)
+            {
+                this.Names = names;
+                this.values = values;
+            }
+
+            #endregion
+
+            #region Overrides
+
+            protected override string[] GetValues() =>
+                this.values
+                    .Select(values => GetValues(values))
+                    .Select(values => ConverterHelper.FormatCsvData(this.valuePrefix, this.typeName, values))
+                    .ToArray();
+
+            #endregion
+
+            #region Support routines
+
+            private static string[] GetValues(string[] values) =>
+                values
+                    .Select(value => $"\"{value}\"")
+                    .ToArray();
+
+            #endregion
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Add a public interface and an internal class to handle fluent serialization, and a related method to the Converter to return a suitably initialised object. Renamed OptionMetadata to OptionTypedMetadata and OptionMetadataDictionary to OptionTypelessMetadata to better reflect their function. Add Option extension methods to retrieve OptionMetadata according to prefix or Type, and to retrieve the property names from a metadata array relating to its type. Added dictionary keys to the converter to expose the keys used for the global and typed configuration dictionary. Added tests.

[REFACTOR] Refactor SerializationProcessor and Serialization

Refactor SerializationProcessor and Serialization in preparation to using the latter as the funtionality of the former. Add OptionsExtensions for OptionType and OptionMember. Add TypeExtensions for a property's declaring type's depth.