### PR TITLE
[FEATURE][REFACTOR][TESTS] Add support for defining serialize element…

### DIFF
--- a/Crowswood.CsvConverter.Tests/UserConfigTests.cs
+++ b/Crowswood.CsvConverter.Tests/UserConfigTests.cs
@@ -1,4 +1,5 @@
-﻿using Crowswood.CsvConverter.Handlers;
+﻿using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Handlers;
 
 namespace Crowswood.CsvConverter.Tests
 {
@@ -45,11 +46,11 @@ TypedConfig,TypeName,ExampleName,ExampleValue2
             Assert.AreEqual(1, handler.GlobalConfig.Length, "Unexpected number of global config items.");
             Assert.AreEqual(1, handler.TypedConfig.Length, "Unexpected number of typed config items.");
 
-            var globalConfig = handler.GetGlobal(name: "ExampleName");
+            var globalConfig = handler.GlobalConfig.GetGlobal(name: "ExampleName");
             Assert.IsNotNull(globalConfig, "Failed to find expected global config item.");
             Assert.AreEqual("ExampleValue", globalConfig.Value, "Unexpected global config value.");
 
-            var typedConfigs = handler.GetTyped(name: "ExampleName");
+            var typedConfigs = handler.TypedConfig.GetTyped(name: "ExampleName");
             Assert.IsNotNull(typedConfigs, "Failed to find expected typed config items.");
             Assert.AreEqual(1, typedConfigs.Count(), "Unexpected number of typed config items retrieved.");
 
@@ -57,7 +58,7 @@ TypedConfig,TypeName,ExampleName,ExampleValue2
             Assert.IsNotNull(typedConfig1, "Failed to find expected typed config item.");
             Assert.AreEqual("ExampleValue2", typedConfig1.Value, "Unexpected typed config value (method 1).");
 
-            var typedConfig2 = handler.GetTyped(typeName: "TypeName", name: "ExampleName");
+            var typedConfig2 = handler.TypedConfig.GetTyped(typeName: "TypeName", name: "ExampleName");
             Assert.IsNotNull(typedConfig2, "Failed to get expected typed config item for type.");
             Assert.AreEqual("ExampleValue2", typedConfig2.Value, "Unexpected typed config value (method 2).");
         }

--- a/Crowswood.CsvConverter/Converter.cs
+++ b/Crowswood.CsvConverter/Converter.cs
@@ -206,7 +206,7 @@ namespace Crowswood.CsvConverter
         /// typed and typeless metadata, typed and typeless data, and comments.
         /// </summary>
         /// <returns>An <see cref="ISerialization"/> object.</returns>
-        public ISerialization Serialize() => new Serialization(this, this.options);
+        public ISerialization Serialize() => new Serialization(this.options);
 
         #endregion
 

--- a/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
+++ b/Crowswood.CsvConverter/Crowswood.CsvConverter.csproj
@@ -47,6 +47,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Options\_OptionSerialize.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Options\Options.cs~RF10c8ef71.TMP" />
     <None Remove="Serialization.cs~RFbb9b9a6.TMP" />
   </ItemGroup>

--- a/Crowswood.CsvConverter/Extensions/ConverterExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/ConverterExtensions.cs
@@ -3,6 +3,18 @@
     public static class ConverterExtensions
     {
         /// <summary>
+        /// Constructs from the <paramref name="values"/> and the specified <paramref name="prefixes"/>
+        /// a single comma separated <see cref="string"/>.
+        /// </summary>
+        /// <param name="values">A <see cref="string[]"/> containing the values.</param>
+        /// <param name="prefixes">A params <see cref="string[]"/> containing any prefixes to include.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string AsCsv(this string[] values, params string[] prefixes) =>
+            string.Join(",",
+                new List<string[]> { prefixes, values, }
+                    .SelectMany(items => items));
+
+        /// <summary>
         /// Deserialize from the <paramref name="stream"/> returning an <see cref="IEnumerable{T}"/> 
         /// of <typeparamref name="TBase"/> objects.
         /// </summary>

--- a/Crowswood.CsvConverter/Extensions/SerializationExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/SerializationExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Crowswood.CsvConverter.Serializations;
+
+namespace Crowswood.CsvConverter.Extensions
+{
+    public static class SerializationExtensions
+    {
+        /// <summary>
+        /// Gets the elements from <paramref name="serializations"/> that are assignable to 
+        /// <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of serialization that is wanted.</typeparam>
+        /// <param name="serializations">An <see cref="IEnumerable{T}"/> of <see cref="BaseSerializationData"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="T"/>.</returns>
+        public static IEnumerable<T> Get<T>(this IEnumerable<BaseSerializationData> serializations)
+            where T : BaseSerializationData =>
+            serializations
+                .Where(s => s.GetType().IsAssignableTo(typeof(T)))
+                .Select(s => s as T)
+                .NotNull();
+    }
+}

--- a/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.ComponentModel;
+using System.Reflection;
 using Crowswood.CsvConverter.Model;
 
 namespace Crowswood.CsvConverter.Extensions
@@ -8,6 +9,28 @@ namespace Crowswood.CsvConverter.Extensions
     /// </summary>
     public static class TypeExtensions
     {
+        /// <summary>
+        /// Gets the Attributes that the <paramref name="type"/> has defined.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Attribute"/>.</returns>
+        public static IEnumerable<Attribute> GetAttributes(this Type type)
+        {
+            var attributes = TypeDescriptor.GetAttributes(type);
+            foreach (Attribute attribute in attributes)
+                yield return attribute;
+        }
+
+        /// <summary>
+        /// Gets the types of the <paramref name="attributes"/>.
+        /// </summary>
+        /// <param name="attributes">An <see cref="IEnumerable{T}"/> of <see cref="Attribute"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Type"/>.</returns>
+        public static IEnumerable<Type> GetAttributeTypes(this IEnumerable<Attribute> attributes) =>
+            attributes
+                .Select(attribute => attribute.GetType())
+                .Distinct();
+
         /// <summary>
         /// Extension method to determine and return the depth of the <see cref="Type"/> in the
         /// hierarchy.
@@ -58,6 +81,15 @@ namespace Crowswood.CsvConverter.Extensions
         public static IEnumerable<PropertyAndAttributePair> GetPropertyAndAttributePairs(this Type type) =>
             type.GetProperties(BindingFlags.Instance |
                                BindingFlags.Public)
+                .Select(property => new PropertyAndAttributePair(property));
+
+        /// <summary>
+        /// Retrieves the <see cref="PropertyAndAttributePair"/> objects for the <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="PropertyAndAttributePair"/> objects.</returns>
+        public static IEnumerable<PropertyAndAttributePair> GetPropertyAndAttributePairs(this PropertyInfo[] properties) =>
+            properties
                 .Select(property => new PropertyAndAttributePair(property));
 
         /// <summary>

--- a/Crowswood.CsvConverter/Extensions/UserConfigExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/UserConfigExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Crowswood.CsvConverter.Interfaces;
+
+namespace Crowswood.CsvConverter.Extensions
+{
+    public static class UserConfigExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="IGlobalConfig"/> item that has the specified <paramref name="name"/>, 
+        /// or null if there is no match.
+        /// </summary>
+        /// <param name="config">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/>.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
+        /// <returns>An <see cref="IGlobalConfig"/> or null.</returns>
+        public static IGlobalConfig? GetGlobal(this IEnumerable<IGlobalConfig> config, string name) =>
+            config.FirstOrDefault(cf => cf.Name == name);
+
+        /// <summary>
+        /// Gets the <see cref="ITypedConfig"/> item that has the specified <paramref name="typeName"/> 
+        /// and <paramref name="name"/>, or null if there is no match.
+        /// </summary>
+        /// <param name="config">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/>.</param>
+        /// <param name="typeName">A <see cref="string"/> that contains the name of a data-type.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
+        /// <returns>An <see cref="ITypedConfig"/> or null.</returns>
+        public static ITypedConfig? GetTyped(this IEnumerable<ITypedConfig> config, string typeName, string name) =>
+            config.FirstOrDefault(cf => cf.TypeName == typeName && cf.Name == name);
+
+        /// <summary>
+        /// Gets all the <see cref="ITypedConfig"/> items that have the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="config">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/>.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/>.</returns>
+        public static IEnumerable<ITypedConfig> GetTyped(this IEnumerable<ITypedConfig> config, string name) =>
+            config.Where(cf => cf.Name == name);
+    }
+}

--- a/Crowswood.CsvConverter/Handlers/ConfigHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/ConfigHandler.cs
@@ -1,5 +1,4 @@
-﻿using Crowswood.CsvConverter.Extensions;
-using Crowswood.CsvConverter.Helpers;
+﻿using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.UserConfig;
 
 namespace Crowswood.CsvConverter.Handlers
@@ -105,47 +104,15 @@ namespace Crowswood.CsvConverter.Handlers
         /// Gets the conversion type prefix.
         /// </summary>
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
-        internal string GetConversionTypePrefix() => 
-            GetGlobal(Configurations.ConversionTypePrefix)?.Value ??
-            this.options.ConversionTypePrefix;
+        internal string GetConversionTypePrefix() =>
+            ConfigHelper.GetConversionTypePrefix(this.globalConfig, this.options);
 
         /// <summary>
         /// Gets the conversion value prefix.
         /// </summary>
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
         internal string GetConversionValuePrefix() =>
-            GetGlobal(Configurations.ConversionValuePrefix)?.Value ??
-            this.options.ConversionValuePrefix;
-
-        /// <summary>
-        /// Gets the <see cref="GlobalConfig"/> item that has the specified <paramref name="name"/>, 
-        /// or null if there is no match.
-        /// </summary>
-        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
-        /// <returns>A <see cref="GlobalConfig"/> or null.</returns>
-        public GlobalConfig? GetGlobal(string name) =>
-            this.globalConfig
-                .FirstOrDefault(config => config.Name == name);
-
-        /// <summary>
-        /// Gets all the <see cref="TypedConfig"/> items that have the specified <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="GlobalConfig"/>.</returns>
-        public IEnumerable<TypedConfig> GetTyped(string name) =>
-            this.typedConfig
-                .Where(config => config.Name == name);
-
-        /// <summary>
-        /// Gets the <see cref="TypedConfig"/> item that has the specified <paramref name="typeName"/> 
-        /// and <paramref name="name"/>, or null if there is no match.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> that contains the name of a data-type.</param>
-        /// <param name="name">A <see cref="string"/> that contains the name of a configuration item.</param>
-        /// <returns>A <see cref="TypedConfig"/> or null.</returns>
-        public TypedConfig? GetTyped(string typeName, string name)=>
-            this.typedConfig
-                .FirstOrDefault(config=> config.TypeName == typeName && config.Name == name);
+            ConfigHelper.GetConversionValuePrefix(this.globalConfig, this.options);
 
         /// <summary>
         /// Gets the property prefix for the specified <paramref name="typeName"/>.
@@ -153,25 +120,14 @@ namespace Crowswood.CsvConverter.Handlers
         /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
         public string GetPropertyPrefix(string typeName) =>
-            GetTyped(typeName, Configurations.PropertyPrefix)?.Value ??
-            GetGlobal(Configurations.PropertyPrefix)?.Value ??
-            this.options.PropertyPrefix; // GetPropertyPrefix
+            ConfigHelper.GetPropertyPrefix(this.globalConfig, this.typedConfig, this.options, typeName);
 
         /// <summary>
         /// Gets all the property prefixes.
         /// </summary>
         /// <returns>A <see cref="string[]"/> containing the prefixes.</returns>
         public string[] GetPropertyPrefixes() =>
-            new List<string?>(
-                GetTyped(Configurations.PropertyPrefix)
-                    .Select(config => config.Value))
-            {
-                GetGlobal(Configurations.PropertyPrefix)?.Value,
-                this.options.PropertyPrefix, // GetPropertyPrefixes
-
-            }.NotNull()
-            .Distinct()
-            .ToArray();
+            ConfigHelper.GetPropertyPrefixes(this.globalConfig, this.typedConfig, this.options);
 
         /// <summary>
         /// Gets the name of the id column for the specified <paramref name="typeName"/>.
@@ -179,11 +135,7 @@ namespace Crowswood.CsvConverter.Handlers
         /// <param name="typeName">A <see cref="string"/> that contains the name of the data type being referenced.</param>
         /// <returns>A <see cref="string"/> containing the name of the id column.</returns>
         public string GetReferenceIdColumnName(string typeName) =>
-            GetTyped(typeName, Configurations.ReferenceIdColumnName)?.Value ??
-            GetGlobal(Configurations.ReferenceIdColumnName)?.Value ??
-            this.options.OptionsReferences.Get(typeName)?.IdPropertyName ??
-            this.options.OptionsReferences.Get()?.IdPropertyName ??
-            Configurations.DefaultIdColumnName;
+            ConfigHelper.GetReferenceIdColumnName(this.globalConfig, this.typedConfig, this.options, typeName);
 
         /// <summary>
         /// Gets the name of the name column for the specified <paramref name="typeName"/>.
@@ -191,11 +143,7 @@ namespace Crowswood.CsvConverter.Handlers
         /// <param name="typeName">A <see cref="string"/> that contains the name of the data type being referenced.</param>
         /// <returns>A <see cref="string"/> containing the name of the name column.</returns>
         public string GetReferenceNameColumnName(string typeName) =>
-            GetTyped(typeName, Configurations.ReferenceNameColumnName)?.Value ??
-            GetGlobal(Configurations.ReferenceNameColumnName)?.Value ??
-            this.options.OptionsReferences.Get(typeName)?.NamePropertyName ??
-            this.options.OptionsReferences.Get()?.NamePropertyName ??
-            Configurations.DefaultNameColumnName;
+            ConfigHelper.GetReferenceNameColumnName(this.globalConfig, this.typedConfig, this.options, typeName);
 
         /// <summary>
         /// Gets the value prefix for the specified <paramref name="typeName"/>.
@@ -203,23 +151,14 @@ namespace Crowswood.CsvConverter.Handlers
         /// <param name="typeName">A <see cref="string"/> containing the name of the type.</param>
         /// <returns>A <see cref="string"/> containing the prefix.</returns>
         public string GetValuePrefix(string typeName) =>
-            GetTyped(typeName, Configurations.ValuesPrefix)?.Value ??
-            GetGlobal(Configurations.ValuesPrefix)?.Value ??
-            this.options.ValuesPrefix;
+            ConfigHelper.GetValuePrefix(this.globalConfig, this.typedConfig, this.options, typeName);
 
         /// <summary>
         /// Gets all the value prefixes.
         /// </summary>
         /// <returns>A <see cref="string[]"/> containing the prefixes.</returns>
         public string[] GetValuePrefixes() =>
-            new List<string?>(
-                GetTyped(Configurations.ValuesPrefix)
-                    .Select(config => config.Value))
-            {
-                GetGlobal(Configurations.ValuesPrefix)?.Value,
-                this.options.ValuesPrefix,
-            }.NotNull()
-            .ToArray();
+            ConfigHelper.GetValuePrefixes(this.globalConfig, this.typedConfig, this.options);
 
         #endregion
     }

--- a/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
@@ -1,5 +1,9 @@
-﻿using Crowswood.CsvConverter.Handlers;
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Handlers;
+using Crowswood.CsvConverter.Interfaces;
 using Crowswood.CsvConverter.UserConfig;
+using static Crowswood.CsvConverter.Handlers.ConfigHandler;
 
 namespace Crowswood.CsvConverter.Helpers
 {
@@ -51,5 +55,134 @@ namespace Crowswood.CsvConverter.Helpers
             return typedConfig;
         }
 
+        /// <summary>
+        /// Gets the value of the static public fields of the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        public static string[] GetValidConfigKeys(Type type) =>
+            type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(field => field.FieldType == typeof(string))
+                .Select(field => field.GetValue(null))
+                .Cast<string>()
+                .ToArray();
+
+        /// <summary>
+        /// Gets the Conversion Type Prefix from the specified <paramref name="globalConfig"/> and 
+        /// <paramref name="options"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <returns>A <see cref="string"/></returns>
+        public static string GetConversionTypePrefix(IEnumerable<IGlobalConfig> globalConfig, Options options) =>
+            globalConfig.GetGlobal(Configurations.ConversionTypePrefix)?.Value ??
+            options.ConversionTypePrefix;
+
+        /// <summary>
+        /// Gets the Conversion Value Prefix from the specified <paramref name="globalConfig"/> and 
+        /// <paramref name="options"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <returns>A <see cref="string"/></returns>
+        public static string GetConversionValuePrefix(IEnumerable<IGlobalConfig> globalConfig, Options options) =>
+            globalConfig.GetGlobal(Configurations.ConversionValuePrefix)?.Value ??
+            options.ConversionValuePrefix;
+
+        /// <summary>
+        /// Gets the Property Prefix from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/> for the specified 
+        /// <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="typeName">A <see cref="string"/> containing the type-name.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string GetPropertyPrefix(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options, string typeName) =>
+            typedConfig.GetTyped(typeName, Configurations.PropertyPrefix)?.Value ??
+            globalConfig.GetGlobal(Configurations.PropertyPrefix)?.Value ??
+            options.PropertyPrefix;
+
+        /// <summary>
+        /// Gets all the Property Prefixes from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        public static string[] GetPropertyPrefixes(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options) =>
+            GetAllItems(globalConfig, typedConfig, options.PropertyPrefix, Configurations.PropertyPrefix);
+
+        /// <summary>
+        /// Gets the ReferenceId Column Name from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/> for the specified 
+        /// <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="typeName">A <see cref="string"/> containing the type-name.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string GetReferenceIdColumnName(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options, string typeName) =>
+            typedConfig.GetTyped(typeName, Configurations.ReferenceIdColumnName)?.Value ??
+            globalConfig.GetGlobal(Configurations.ReferenceIdColumnName)?.Value ??
+            options.OptionsReferences.Get(typeName)?.IdPropertyName ??
+            options.OptionsReferences.Get()?.IdPropertyName ??
+            Configurations.DefaultIdColumnName;
+
+        /// <summary>
+        /// Gets the ReferenceName Column Name from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/> for the specified 
+        /// <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="typeName">A <see cref="string"/> containing the type-name.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string GetReferenceNameColumnName(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options, string typeName) =>
+            typedConfig.GetTyped(typeName, Configurations.ReferenceNameColumnName)?.Value ??
+            globalConfig.GetGlobal(Configurations.ReferenceNameColumnName)?.Value ??
+            options.OptionsReferences.Get(typeName)?.NamePropertyName ??
+            options.OptionsReferences.Get()?.NamePropertyName ??
+            Configurations.DefaultNameColumnName;
+
+        /// <summary>
+        /// Gets the Value Prefix from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/> for the specified 
+        /// <paramref name="typeName"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <param name="typeName">A <see cref="string"/> containing the type-name.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string GetValuePrefix(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options, string typeName) =>
+            typedConfig.GetTyped(typeName, Configurations.ValuesPrefix)?.Value ??
+            globalConfig.GetGlobal(Configurations.ValuesPrefix)?.Value ??
+            options.ValuesPrefix;
+
+        /// <summary>
+        /// Get all the Value Prefixes from the specified <paramref name="globalConfig"/>, 
+        /// <paramref name="typedConfig"/> and <paramref name="options"/>.
+        /// </summary>
+        /// <param name="globalConfig">An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</param>
+        /// <param name="typedConfig">An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</param>
+        /// <param name="options">An <see cref="Options"/> object.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string[] GetValuePrefixes(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, Options options) =>
+            GetAllItems(globalConfig, typedConfig, options.ValuesPrefix, Configurations.ValuesPrefix);
+
+        private static string[] GetAllItems(IEnumerable<IGlobalConfig> globalConfig, IEnumerable<ITypedConfig> typedConfig, string optionsItemValue, string configurationKey)=>
+            new List<string?>(
+                typedConfig.GetTyped(configurationKey)
+                    .Select(config => config.Value) )
+            {
+                globalConfig.GetGlobal(configurationKey)?.Value,
+                optionsItemValue
+            }.NotNull()
+            .ToArray();
     }
 }

--- a/Crowswood.CsvConverter/Interfaces/IGlobalConfig.cs
+++ b/Crowswood.CsvConverter/Interfaces/IGlobalConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace Crowswood.CsvConverter.Interfaces
+{
+    public interface IGlobalConfig
+    {
+        string Name { get; }
+
+        string Value { get; }
+    }
+}

--- a/Crowswood.CsvConverter/Interfaces/IOptionSerialization.cs
+++ b/Crowswood.CsvConverter/Interfaces/IOptionSerialization.cs
@@ -1,9 +1,9 @@
 ﻿namespace Crowswood.CsvConverter.Interfaces
 {
     /// <summary>
-    /// Interface that describes a full fluent serialization object.
+    /// Interface that describes an OptionSerialization object.
     /// </summary>
-    public interface ISerialization
+    public interface IOptionSerialization
     {
         /// <summary>
         /// Specifies the <paramref name="key"/> and <paramref name="value"/> of global 
@@ -12,14 +12,14 @@
         /// <param name="key">A <see cref="string"/> containing the key.</param>
         /// <param name="value">A <see cref="string"/> containing the value.</param>
         /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
-        ISerialization GlobalConfig(string key, string  value);
+        IOptionSerialization GlobalConfig(string key, string value);
 
         /// <summary>
         /// Specifies the <paramref name="globalConfiguration"/> to include in the serialization.
         /// </summary>
         /// <param name="globalConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the global configuration.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization GlobalConfig(Dictionary<string, string> globalConfiguration);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization GlobalConfig(Dictionary<string, string> globalConfiguration);
 
         /// <summary>
         /// Specifies the <paramref name="key"/> and <paramref name="value"/> of a type 
@@ -29,7 +29,7 @@
         /// <param name="key">A <see cref="string"/> containing the key.</param>
         /// <param name="value">A <see cref="string"/> containing the value.</param>
         /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfig<TObject>(string key, string value)
+        IOptionSerialization TypeConfig<TObject>(string key, string value)
             where TObject : class;
 
         /// <summary>
@@ -40,7 +40,7 @@
         /// <param name="key">A <see cref="string"/> containing the key.</param>
         /// <param name="value">A <see cref="string"/> containing the value.</param>
         /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfig(Type type, string key, string value);
+        IOptionSerialization TypeConfig(Type objectType, string key, string value);
 
         /// <summary>
         /// Specifies the <paramref name="key"/> and <paramref name="value"/> of a type 
@@ -50,7 +50,7 @@
         /// <param name="key">A <see cref="string"/> containing the key.</param>
         /// <param name="value">A <see cref="string"/> containing the value.</param>
         /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfg(string typeName, string key, string value);
+        IOptionSerialization TypeConfig(string objectTypeName, string key, string value);
 
         /// <summary>
         /// Specifies the <paramref name="typeConfiguration"/> to include in the serialization for 
@@ -58,48 +58,48 @@
         /// </summary>
         /// <typeparam name="TObject">The type to associate with this type configuration.</typeparam>
         /// <param name="typeConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type configuration.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
             where TObject : class;
 
         /// <summary>
         /// Specifies the <paramref name="typeConfiguration"/> to include in the serialization for 
-        /// the specified <paramref name="type"/>.
+        /// the specified <paramref name="objectType"/>.
         /// </summary>
-        /// <param name="type">A <see cref="Type"/> associated with this type configuration.</param>
+        /// <param name="objectType">A <see cref="Type"/> associated with this type configuration.</param>
         /// <param name="typeConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type configuration.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfig(Type type, Dictionary<string, string> typeConfiguration);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization TypeConfig(Type objectType, Dictionary<string, string> typeConfiguration);
 
         /// <summary>
         /// Specifies the <paramref name="typeConfiguration"/> to include in the serialization for 
-        /// the specified <paramref name="typeName"/>.
+        /// the specified <paramref name="objectTypeName"/>.
         /// </summary>
-        /// <param name="typeName">A <see cref="string"/> containing the name of the type to associate with this type configuration.</param>
+        /// <param name="objectTypeName">A <see cref="string"/> containing the name of the type to associate with this type configuration.</param>
         /// <param name="typeConfiguration">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type configuration.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConfig(string typeName, Dictionary<string, string> typeConfiguration);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization TypeConfig(string objectTypeName, Dictionary<string, string> typeConfiguration);
 
         /// <summary>
         /// Specifies the number of blank lines to include in the serialization.
         /// </summary>
         /// <param name="number">An <see cref="int"/> that contains the number of blank lines to include; defaults to one.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization BlankLine(int number = 1);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization BlankLine(int number = 1);
 
         /// <summary>
         /// Specifies the <paramref name="typeConversion"/> to include in the serialization.
         /// </summary>
         /// <param name="typeConversion">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the type conversion.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypeConversion(Dictionary<string, string> typeConversion);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization TypeConversion(Dictionary<string, string> typeConversion);
 
         /// <summary>
         /// Specifies the <paramref name="valueConversion"/> to include in the serialization.
         /// </summary>
         /// <param name="valueConversion">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> that contains the value conversion.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization ValueConversion(Dictionary<string, string> valueConversion);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization ValueConversion(Dictionary<string, string> valueConversion);
 
         /// <summary>
         /// Specifies the <paramref name="comment"/> and the <paramref name="commentPrefix"/> to 
@@ -107,8 +107,8 @@
         /// </summary>
         /// <param name="commentPrefix">A <see cref="string"/> that contains the comment prefix; it must correspond to one of the defined comment prefixes.</param>
         /// <param name="comment">A <see cref="string"/> that contains the text of the comment.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization Comment(string commentPrefix, params string[] comments);
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
+        IOptionSerialization Comment(string commentPrefix, params string[] comments);
 
         /// <summary>
         /// Specifies the <paramref name="metadata"/> for <typeparamref name="TObject"/> to 
@@ -117,11 +117,11 @@
         /// <typeparam name="TObject">The type of the object that the metadata describes.</typeparam>
         /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
         /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <typeparamref name="TMetadata"/> that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typed object data.
         /// </remarks>
-        ISerialization TypedMetadata<TMetadata, TObject>(IEnumerable<TMetadata> metadata)
+        IOptionSerialization TypedMetadata<TMetadata, TObject>(IEnumerable<TMetadata> metadata)
             where TObject : class
             where TMetadata : class;
 
@@ -132,12 +132,12 @@
         /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
         /// <param name="dataType">The <see cref="Type"/> of the data that the metadata is attached to.</param>
         /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <typeparamref name="TMetadata"/> that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typed object data, but the use of <seealso cref="TypedMetadata{TObject, TMetadata}(IEnumerable{TMetadata})"/>
         /// is prefered as it gives better type safety.
         /// </remarks>
-        ISerialization TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata)
+        IOptionSerialization TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata)
             where TMetadata : class;
 
         /// <summary>
@@ -147,13 +147,13 @@
         /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
         /// <param name="dataTypeName">A <see cref="string"/> that contains the name of the data that the metadata is attached ot.</param>
         /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <typeparamref name="TMetadata"/> that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typeless object data.
         /// Can also be used with typed object data, but the use of <seealso cref="TypedMetadata{TObject, TMetadata}(IEnumerable{TMetadata})"/>
         /// is prefered as it gives better type safety.
         /// </remarks>
-        ISerialization TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata)
+        IOptionSerialization TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata)
             where TMetadata : class;
 
         /// <summary>
@@ -163,11 +163,11 @@
         /// <typeparam name="TObject">The type of the object that the metadata describes.</typeparam>
         /// <param name="metadataPrefix">A <see cref="string"/> that contains the type name of the metadata.</param>
         /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the property name that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typed object data.
         /// </remarks>
-        ISerialization TypelessMetadata<TObject>(string metadataPrefix, Dictionary<string, string> metadata)
+        IOptionSerialization TypelessMetadata<TObject>(string metadataPrefix, Dictionary<string, string> metadata)
             where TObject : class;
 
         /// <summary>
@@ -178,12 +178,12 @@
         /// <param name="dataType">The <see cref="Type"/> of object that the metadata describes.</param>
         /// <param name="metadataPrefix">A <see cref="string"/> that contains the type name of the metadata.</param>
         /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the property name that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typed object data, but the use of <seealso cref="TypelessMetadata{TObject}(string, Dictionary{string, string})"/>
         /// is prefered as it gives better type safety.
         /// </remarks>
-        ISerialization TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata);
+        IOptionSerialization TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata);
 
         /// <summary>
         /// Specifies the <paramref name="metadata"/> that has the specified <paramref name="metadataPrefix"/> 
@@ -192,37 +192,18 @@
         /// <param name="dataTypeName">A <see cref="string"/> that contains the type name of the object that the metadata describes.</param>
         /// <param name="metadataPrefix">A <see cref="string"/> that contains the prefix of the metadata.</param>
         /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the property name that contains the metadata.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
+        /// <returns>An <see cref="IOptionSerialization"/> object to allow chaining.</returns>
         /// <remarks>
         /// For use with typeless object data.
         /// Can also be used with typed object data, but the use of <seealso cref="TypelessMetadata{TObject}(string, Dictionary{string, string})"/>
         /// is prefered as it gives better type safety.
         /// </remarks>
-        ISerialization TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata);
+        IOptionSerialization TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata);
 
         /// <summary>
-        /// Specifies the <paramref name="data"/> to include in the serialization.
+        /// Serializes to a <see cref="string[]"/>.
         /// </summary>
-        /// <typeparam name="Tobject">The type of the data.</typeparam>
-        /// <param name="data">An <see cref="IEnumerable{T}"/> of <typeparamref name="Tobject"/> that contains the data.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypedData<Tobject>(IEnumerable<Tobject> data)
-            where Tobject : class;
-
-        /// <summary>
-        /// Specifies the <paramref name="data"/> for the specified <paramref name="typeName"/> to 
-        /// include in the serialization.
-        /// </summary>
-        /// <param name="typeName">A <see cref="string"/> that contains the type name of the data.</param>
-        /// <param name="names">A <see cref="string[]"/> that contains the property names of the data.</param>
-        /// <param name="values">An <see cref="IEnumerable{T}"/> of <see cref="string[]"/> containing the values of the data.</param>
-        /// <returns>An <see cref="ISerialization"/> object to allow chaining.</returns>
-        ISerialization TypelessData(string typeName, string[] names, IEnumerable<string[]> values);
-
-        /// <summary>
-        /// Serializes the previously specified data to a string.
-        /// </summary>
-        /// <returns>A <see cref="string"/> containing the serialized data.</returns>
-        string ToString();
+        /// <returns>A <see cref="string[]"/>.</returns>
+        string[] ToArray();
     }
 }

--- a/Crowswood.CsvConverter/Interfaces/ITypedConfig.cs
+++ b/Crowswood.CsvConverter/Interfaces/ITypedConfig.cs
@@ -1,0 +1,11 @@
+﻿namespace Crowswood.CsvConverter.Interfaces
+{
+    public interface ITypedConfig
+    {
+        string Name { get; }
+
+        string TypeName { get; }
+
+        string Value { get; }
+    }
+}

--- a/Crowswood.CsvConverter/Options/OptionType.cs
+++ b/Crowswood.CsvConverter/Options/OptionType.cs
@@ -28,7 +28,7 @@ namespace Crowswood.CsvConverter
 
         protected OptionType() => this.Name = this.Type.Name;
 
-        protected OptionType(string name) : this() => this.Name = name;
+        protected OptionType(string name) => this.Name = name;
 
         #endregion
     }

--- a/Crowswood.CsvConverter/Options/Options.cs
+++ b/Crowswood.CsvConverter/Options/Options.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using Crowswood.CsvConverter.Interfaces;
 
 namespace Crowswood.CsvConverter
 {
@@ -54,6 +55,11 @@ namespace Crowswood.CsvConverter
         internal OptionReference[] OptionsReferences => this.optionsReferences.ToArray();
 
         /// <summary>
+        /// Gets the serialization options.
+        /// </summary>
+        internal IOptionSerialization OptionSerialize { get; }
+
+        /// <summary>
         /// Gets the <see cref="OptionType"/> instances assigned to the curent <see cref="Options"/>
         /// instance.
         /// </summary>
@@ -102,7 +108,7 @@ namespace Crowswood.CsvConverter
         /// <summary>
         /// Creates a new <see cref="Options"/> instance.
         /// </summary>
-        public Options() { }
+        public Options() => this.OptionSerialize = new Serialization(this);
 
         #endregion
 
@@ -128,6 +134,7 @@ namespace Crowswood.CsvConverter
 
             return this;
         }
+
 
         /// <summary>
         /// Adds the specified <paramref name="optionMember"/>.
@@ -201,6 +208,23 @@ namespace Crowswood.CsvConverter
         /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
         public Options ForReferences<T>(string idPropertyName, string namePropertyName)=>
             AddReference(new OptionReferenceType<T>(idPropertyName, namePropertyName));
+
+
+        /// <summary>
+        /// Allows the addition of <see cref="IOptionSerialization"/> options.
+        /// </summary>
+        /// <param name="func">A <see cref="Func{T, TResult}"/> that takes and returns a <see cref="IOptionSerialization"/> object.</param>
+        /// <returns>The <see cref="Options"/> object to allow calls to be chained.</returns>
+        /// <remarks>
+        /// Use a lambda in the form 
+        /// <code>serialise => serialise.Method(...)</code>
+        /// Methods can be chained in the fluent style.
+        /// </remarks>
+        public Options Serialize(Func<IOptionSerialization, IOptionSerialization> func)
+        {
+            func(this.OptionSerialize);
+            return this;
+        }
 
 
         /// <summary>

--- a/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
+++ b/Crowswood.CsvConverter/Processors/SerializationProcessor.cs
@@ -36,14 +36,20 @@ namespace Crowswood.CsvConverter.Processors
         {
             var lines = new List<string>();
 
-            var types = this.options.OptionTypes.Any()
-                ? this.options.OptionTypes.Select(optionType => optionType.Type)
-                : values.Select(value => value.GetType()).Distinct();
+            lines.AddRange(this.options.OptionSerialize.ToArray());
+
+            var types = this.options.OptionTypes.Any(ot => ot.Type != typeof(Type))
+                ? this.options.OptionTypes
+                    .Where(ot => ot.Type != typeof(Type))
+                    .Select(optionType => optionType.Type)
+                : values
+                    .Select(value => value.GetType())
+                    .Distinct();
 
             foreach (var type in types)
             {
                 lines.AddRange(ConvertFrom(type, values));
-                lines.Add(Environment.NewLine);
+                lines.Add(string.Empty);
             }
 
             var text = string.Join(Environment.NewLine, lines);
@@ -58,8 +64,12 @@ namespace Crowswood.CsvConverter.Processors
         internal string Process(Dictionary<string, (string[], IEnumerable<string[]>)> data)
         {
             var lines =
+                this.options.OptionSerialize
+                    .ToArray()
+                    .ToList();
+            lines.AddRange(
                 data.Select(kvp => Process(kvp.Key, kvp.Value.Item1, kvp.Value.Item2))
-                    .SelectMany(item => item);
+                    .SelectMany(item => item));
 
             var text = string.Join(Environment.NewLine, lines);
             return text;
@@ -199,7 +209,7 @@ namespace Crowswood.CsvConverter.Processors
                                                                     values)));
 
             // Add a blank line to separate the block of data for this type from any others.
-            results.Add(Environment.NewLine);
+            results.Add(string.Empty);
 
             return results;
         }

--- a/Crowswood.CsvConverter/Serialization.cs
+++ b/Crowswood.CsvConverter/Serialization.cs
@@ -1,627 +1,561 @@
 ﻿using System.Reflection;
 using Crowswood.CsvConverter.Extensions;
-using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Interfaces;
+using Crowswood.CsvConverter.Serializations;
 
 namespace Crowswood.CsvConverter
 {
     /// <summary>
     /// An internal class to manage the serialization of data using a fluent interface.
     /// </summary>
-    internal class Serialization :
+    /// <remarks>
+    /// Implements two interfaces with overlapping method declarations, the only difference in the 
+    /// main being the return types, that of the interface itself for the fluent api, so both 
+    /// interfaces are implemented explicitly.
+    /// Each explicit interface method simply calls a private routine of the same name and with 
+    /// the parameters and supplies the return value via an implicit cast from the class instance 
+    /// to the interface instance.
+    /// There are two 'build' methods that conclude the fluent chain, one for each interface:
+    /// <c>.ToArray();</c> and <c>.ToString();</c>.
+    /// </remarks>
+    internal partial class Serialization : 
+        IOptionSerialization,
         ISerialization
     {
         #region Fields
 
         private readonly List<BaseSerializationData> serializations = new();
 
-        private readonly ConfigHandler configHandler;
-
         #endregion
 
         #region Properties
 
-        public Converter Converter { get; }
+        /// <summary>
+        /// Gets the <see cref="Options"/> that the current instance is using.
+        /// </summary>
         public Options Options { get; }
 
         #endregion
 
         #region Constructors
 
-        internal Serialization(Converter converter, Options options)
-        {
-            this.Converter = converter;
-            this.Options = options;
+        internal Serialization(Options options) => this.Options = options;
 
-            this.configHandler = new ConfigHandler(this.Options);
+        #endregion
+
+        #region IOptionSerialization methods
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.GlobalConfig(string key, string value) => 
+            GlobalConfig(key, value);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.GlobalConfig(Dictionary<string, string> globalConfiguration) => 
+            GlobalConfig(globalConfiguration);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig<TObject>(string key, string value) =>
+            TypeConfig<TObject>(key, value);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig(Type type, string key, string value) =>
+            TypeConfig(type, key, value);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig(string typeName, string key, string value) => 
+            TypeConfig(typeName, key, value);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
+            where TObject : class => TypeConfig<TObject>(typeConfiguration);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig(Type type, Dictionary<string, string> typeConfiguration) =>
+            TypeConfig(type, typeConfiguration);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConfig(string typeName, Dictionary<string, string> typeConfiguration) =>
+            TypeConfig(typeName, typeConfiguration);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.BlankLine(int number) => BlankLine(number);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypeConversion(Dictionary<string, string> typeConversion) =>
+            TypeConversion(typeConversion);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.ValueConversion(Dictionary<string, string> valueConversion) => 
+            ValueConversion(valueConversion);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.Comment(string commentPrefix, params string[] comments) => 
+            Comment(commentPrefix, comments);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypedMetadata<TMetadata, TObject>(IEnumerable<TMetadata> metadata) 
+            where TMetadata : class
+            where TObject : class => TypedMetadata<TMetadata, TObject>(metadata);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata) =>
+            TypedMetadata<TMetadata>(dataType, metadata);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata) =>
+            TypedMetadata(dataTypeName, metadata);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypelessMetadata<TObject>(string metadataPrefix, Dictionary<string, string> metadata) =>
+            TypelessMetadata<TObject>(metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata) =>
+            TypelessMetadata(dataType, metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        IOptionSerialization IOptionSerialization.TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata) => 
+            TypelessMetadata(dataTypeName, metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        string[] IOptionSerialization.ToArray() => ToArray();
+
+        #endregion
+
+        #region ISerialization methods
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.GlobalConfig(string key, string value) => 
+            GlobalConfig(key, value);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.GlobalConfig(Dictionary<string, string> globalConfiguration) =>
+            GlobalConfig(globalConfiguration);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfig<TObject>(string key, string value) =>
+            TypeConfig<TObject>(key, value);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfig(Type type, string key, string value) => 
+            TypeConfig(type, key, value);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfg(string typeName, string key, string value) => 
+            TypeConfig(typeName, key, value);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
+            where TObject : class => TypeConfig<TObject>(typeConfiguration);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfig(Type type, Dictionary<string, string> typeConfiguration) =>
+            TypeConfig(type, typeConfiguration);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConfig(string typeName, Dictionary<string, string> typeConfiguration) => 
+            TypeConfig(typeName, typeConfiguration);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.BlankLine(int number) => BlankLine(number);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypeConversion(Dictionary<string, string> typeConversion) => 
+            TypeConversion(typeConversion);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.ValueConversion(Dictionary<string, string> valueConversion) => 
+            ValueConversion(valueConversion);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.Comment(string commentPrefix, params string[] comments) => 
+            Comment(commentPrefix, comments);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypedMetadata<TMetadata, TObject>(IEnumerable<TMetadata> metadata) =>
+            TypedMetadata<TMetadata, TObject>(metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata) =>
+            TypedMetadata<TMetadata>(dataType, metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata) => 
+            TypedMetadata<TMetadata>(dataTypeName, metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypelessMetadata<TObject>(string metadataPrefix, Dictionary<string, string> metadata) => 
+            TypelessMetadata<TObject>(metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata) =>
+            TypelessMetadata(dataType, metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata) => 
+            TypelessMetadata(dataTypeName, metadataPrefix, metadata);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypedData<Tobject>(IEnumerable<Tobject> data) => 
+            TypedData(data);
+
+        /// <inheritdoc/>
+        ISerialization ISerialization.TypelessData(string typeName, string[] names, IEnumerable<string[]> values) => 
+            TypelessData(typeName, names, values);
+
+        /// <inheritdoc/>
+        string ISerialization.ToString()
+        {
+            // Do pre-serialization adjustments.
+            PreSerializationAdjustments();
+
+            // Finally do the serialization.
+            var result =
+                string.Join(Environment.NewLine,
+                            ToArray(this.Options.OptionSerialize.ToArray()));
+            return result;
         }
 
         #endregion
 
-        #region Interface methods
+        #region Instance methods for interfaces
 
-        /// <inheritdoc/>
-        public ISerialization GlobalConfig(Dictionary<string, string> globalConfiguration)
-        {
-            this.serializations.Add(
-                new GlobalConfigData(globalConfiguration));
-            return this;
-        }
+        private Serialization GlobalConfig(string key, string value) => 
+            Add(new GlobalConfigData(new Dictionary<string, string> { [key] = value, }));
 
-        /// <inheritdoc/>
-        public ISerialization TypeConfig(string typeName, Dictionary<string, string> typeConfiguration)
-        {
-            this.serializations.Add(
-                new TypedConfigData(typeName, typeConfiguration));
-            return this;
-        }
+        private Serialization GlobalConfig(Dictionary<string, string> globalConfiguration) =>
+            Add(new GlobalConfigData(globalConfiguration));
 
-        /// <inheritdoc/>
-        public ISerialization BlankLine(int number = 1)
-        {
-            this.serializations.Add(
-                new BlankLinesData(number));
-            return this;
-        }
+        private Serialization TypeConfig<TObject>(string key, string value)
+            where TObject : class => TypeConfig(typeof(TObject), key, value);
 
-        /// <inheritdoc/>
-        public ISerialization TypeConversion(Dictionary<string, string> typeConversion)
-        {
-            this.serializations.Add(
-                new TypeConversionData(typeConversion));
-            return this;
-        }
+        private Serialization TypeConfig(Type type, string key, string value)=>
+            TypeConfig(type.Name, key, value);
 
-        /// <inheritdoc/>
-        public ISerialization ValueConversion(Dictionary<string, string> valueConversion)
-        {
-            this.serializations.Add(
-                new ValueConversionData(valueConversion));
-            return this;
-        }
+        private Serialization TypeConfig(string typeName, string key, string value) =>
+            Add(new TypedConfigData(typeName, new Dictionary<string, string> { [key] = value, }));
 
-        /// <inheritdoc/>
-        public ISerialization Comment(string commentPrefix, params string[] comments)
-        {
-            this.serializations.Add(
-                new CommentData(commentPrefix, comments));
-            return this;
-        }
+        private Serialization TypeConfig<TObject>(Dictionary<string, string> typeConfiguration)
+            where TObject : class => TypeConfig(typeof(TObject), typeConfiguration);
 
-        /// <inheritdoc/>
-        public ISerialization TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata)
+        private Serialization TypeConfig(Type type, Dictionary<string, string> typeConfiguration) =>
+            TypeConfig(type.Name, typeConfiguration);
+
+        private Serialization TypeConfig(string typeName, Dictionary<string, string> typeConfiguration) => 
+            Add(new TypedConfigData(typeName, typeConfiguration));
+
+        private Serialization BlankLine(int number)=> Add(new BlankLinesData(number));
+
+        private Serialization TypeConversion(Dictionary<string, string> typeConversion) => 
+            Add(new TypeConversionData(typeConversion));
+
+        private Serialization ValueConversion(Dictionary<string, string> valueConversion) => 
+            Add(new ValueConversionData(valueConversion));
+
+        private Serialization Comment(string commentPrefix, string[] comments) => 
+            Add(new CommentData(commentPrefix, comments));
+
+        private Serialization TypedMetadata<TMetadata, TObject>(IEnumerable<TMetadata> metadata)
             where TMetadata : class
+            where TObject : class => TypedMetadata<TMetadata>(GetTypeName<TObject>(), metadata);
+
+        private Serialization TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata) 
+            where TMetadata : class => TypedMetadata<TMetadata>(GetTypeName(dataType), metadata);
+
+        private Serialization TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata)
+            where TMetadata : class => Add(new TypedMetadataData<TMetadata>(new SerializationFactory(this), dataTypeName, metadata));
+
+        private Serialization TypelessMetadata<TObject>(string metadataPrefix, Dictionary<string, string> metadata)
+            where TObject : class => TypelessMetadata(GetTypeName<TObject>(), metadataPrefix, metadata);
+
+        private Serialization TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata) =>
+            TypelessMetadata(GetTypeName(dataType), metadataPrefix, metadata);
+
+        private Serialization TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata) =>
+            Add(new TypelessMetadataData(new SerializationFactory(this), dataTypeName, metadataPrefix, metadata));
+
+        private Serialization TypedData<TObject>(IEnumerable<TObject> data) where TObject : class =>
+            Add(new TypedObjectData<TObject>(new SerializationFactory(this), GetTypeName<TObject>(), data));
+
+        private Serialization TypelessData(string typeName, string[] names, IEnumerable<string[]> values) =>
+            Add(new TypelessObjectData(new SerializationFactory(this), typeName, names, values));
+
+        #endregion
+
+        #region Support routines
+
+        /// <summary>
+        /// Adds the specified <paramref name="data"/> to the <seealso cref="serializations"/> 
+        /// list and returns the current instance.
+        /// </summary>
+        /// <param name="data">A <see cref="BaseSerializationData"/> object.</param>
+        /// <returns>The current instance which can be passed back by the calling routine and so enable fluent chaining.</returns>
+        protected Serialization Add(BaseSerializationData data)
         {
-            var metadataType = typeof(TMetadata);
-            var optionMetadata =
-                this.Options.GetOptionMetadata(metadataType) ??
-                throw new InvalidOperationException(
-                    $"No Metadata definition in Options for '{metadataType.Name}'.");
-
-            this.serializations.Add(
-                new TypedMetadataData<TMetadata>(dataTypeName,
-                                                 optionMetadata.Prefix,
-                                                 optionMetadata.PropertyNames,
-                                                 metadata));
-
+            this.serializations.Add(data);
             return this;
         }
 
-        /// <inheritdoc/>
-        public ISerialization TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata)
+        /// <summary>
+        /// Add into the <seealso cref="serializations"/> new <see cref="TypedMetadataData{TMetadata}"/> 
+        /// as defined in the <paramref name="objectDataMetadataTypes"/> using the specified 
+        /// <paramref name="typedObjectData"/>.
+        /// </summary>
+        /// <param name="objectDataMetadataTypes">A <see cref="List{T}"/> of <see cref="Tuple{T1, T2}"/> of <see cref="Type"/> and <see cref="List{T}"/> of <see cref="Type"/> that contains the object data and metadata types that define the <see cref="TypedMetadataData{TMetadata}"/> instances to insert.</param>
+        /// <param name="typedObjectData">An <see cref="IEnumerable{T}"/> of <see cref="TypedObjectData"/> containing the existing typed object data serializations.</param>
+        private void AddMetadataSerializations(List<(Type ObjectType, List<Type> MetadataTypes)> objectDataMetadataTypes, IEnumerable<TypedObjectData> typedObjectData)=>
+            objectDataMetadataTypes
+                .ForEach(item =>
+                    AddMetadataSerializations(typedObjectData, item.ObjectType, item.MetadataTypes));
+
+        /// <summary>
+        /// Add into the <seealso cref="serializations"/> before the <see cref="TypedObjectData{TObject}"/> 
+        /// serialization for the specified <paramref name="objectType"/> from the specified 
+        /// <paramref name="typedObjectData"/> a set of <see cref="TypedMetadataData{TMetadata}"/>
+        /// for the <paramref name="metadataTypes"/>.
+        /// </summary>
+        /// <param name="typedObjectData">An <see cref="IEnumerable{T}"/> of <see cref="TypedObjectData"/> containing the existing typed object data serializations.</param>
+        /// <param name="objectType">A <see cref="Type"/> indicating the type of the object data.</param>
+        /// <param name="metadataTypes">A <see cref="List{T}"/> of <see cref="Type"/> containing the types of types of the metadata serializations.</param>
+        private void AddMetadataSerializations(IEnumerable<TypedObjectData> typedObjectData, Type objectType, IEnumerable<Type> metadataTypes)
         {
-            var optionMetadata =
-                this.Options.GetOptionMetadata(metadataPrefix) ?? 
-                throw new InvalidOperationException(
-                    $"No Metadata definition in Options for a prefix of '{metadataPrefix}'.");
+            // Find the position of the object data serialization
 
-            this.serializations.Add(
-                new TypelessMetadataData(dataTypeName,
-                                         optionMetadata.Prefix,
-                                         optionMetadata.PropertyNames,
-                                         metadata));
+            var objectDataSerialization =
+                typedObjectData
+                    .FirstOrDefault(item => item.Type == objectType);
+            if (objectDataSerialization is null) 
+                return;
 
-            return this;
+            var index = this.serializations.IndexOf(objectDataSerialization);
+            if (index == -1) 
+                return;
+
+            var dataTypeName = GetTypeName(objectType);
+
+            // Now retrieve the metadata and filter by the the definitions in Options.
+            var metadata =
+                objectType.GetAttributes()
+                    .Where(item => this.Options.OptionMetadata.Any(om => om.Type == item.GetType()))
+                    .ToList();
+
+            // Create the required metadata serialization objects.
+            var metadataSerializations =
+                metadataTypes
+                    .Select(metadataType =>
+                        TypedMetadataData.Create(metadataType,
+                                                 this,
+                                                 dataTypeName,
+                                                 metadata))
+                    .ToList();
+            this.serializations.InsertRange(index, metadataSerializations);
         }
 
-        /// <inheritdoc/>
-        public ISerialization TypedData<Tobject>(IEnumerable<Tobject> data)
-            where Tobject : class
+        /// <summary>
+        /// Determines and returns a list of the object type and metadata type combinations that 
+        /// are missing from the <seealso cref="serializations"/> using the specified <paramref name="typedObjectData"/> 
+        /// and <paramref name="typedMetadataData"/>.
+        /// </summary>
+        /// <param name="typedObjectData">A <see cref="List{T}"/> of <see cref="TypedObjectData"/> instances.</param>
+        /// <param name="typedMetadataData">A <see cref="List{T}"/> of <see cref="TypedMetadataData"/> instances.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="Type"/> and <see cref="List{T}"/> of <see cref="Type"/>.</returns>
+        private List<(Type ObjectType, List<Type> MetadataTypes)> GetObjectTypeMetadataTypeCombinations(IEnumerable<TypedObjectData> typedObjectData, IEnumerable<TypedMetadataData> typedMetadataData)
         {
-            var type = typeof(Tobject);
-            var typeName =
-                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-                type.Name;
-            var propertyPrefix =
-                this.configHandler.GetPropertyPrefix(typeName);
-            var valuePrefix =
-                this.configHandler.GetValuePrefix(typeName);
+            var combinations =
+                typedObjectData
+                    .Select(item => item.Type)
+                    .Select(type => new
+                    {
+                        ObjectType = type,
+                        MetadataTypes =
+                            type.GetAttributes()
+                                .GetAttributeTypes()
+                                .Where(attrType => this.Options.OptionMetadata.Any(om => om.Type == attrType))
+                                .ToArray(),
+                    })
+                    .Select(item =>
+                        item.MetadataTypes
+                            .Select(metadataType => new { item.ObjectType, MetadataType = metadataType, }))
+                    .SelectMany(item => item)
+                    .Select(pair => (pair.ObjectType, pair.MetadataType))
+                    .ToList();
 
-            this.serializations.Add(
-                new TypedDataData<Tobject>(propertyPrefix, valuePrefix, typeName, data));
-            return this;
+            combinations.
+                RemoveAll(item =>
+                    typedMetadataData
+                        .Any(serialization =>
+                            serialization.MetadataType == item.ObjectType &&
+                            serialization.MetadataTypeName == item.MetadataType.Name));
+
+            var results =
+                combinations
+                    .Select(item => item.ObjectType)
+                    .Distinct()
+                    .Select(objectType => new
+                    {
+                        ObjectType = objectType,
+                        MetadataTypes =
+                            combinations
+                                .Where(item => item.ObjectType == objectType)
+                                .Select(item => item.MetadataType)
+                                .ToList()
+                    })
+                    .Select(item => (item.ObjectType, item.MetadataTypes))
+                    .ToList();
+
+            return results;
         }
 
-        /// <inheritdoc/>
-        public ISerialization TypelessData(string typeName, string[] names, IEnumerable<string[]> values)
-        {
-            var propertyPrefix =
-                this.configHandler.GetPropertyPrefix(typeName);
-            var valuePrefix =
-                this.configHandler.GetValuePrefix(typeName);
+        /// <summary>
+        /// Gets the type name from either the <typeparamref name="T"/> or its 
+        /// <see cref="CsvConverterClassAttribute"/> if any.
+        /// </summary>
+        /// <typeparam name="T">The type of object.</typeparam>
+        /// <returns>A <see cref="string"/>.</returns>
+        private static string GetTypeName<T>() => GetTypeName(typeof(T));
 
-            this.serializations.Add(new TypelessDataData(propertyPrefix, valuePrefix, typeName, names, values));
-            return this;
+        /// <summary>
+        /// Gets the type name from either the specified <paramref name="type"/> or its 
+        /// <see cref="CsvConverterClassAttribute"/> if any.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        private static string GetTypeName(Type type) =>
+            type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+            type.Name;
+
+        /// <summary>
+        /// Perform pre-serialization adjustments.
+        /// </summary>
+        /// <remarks>
+        /// The adjustments include adding in any <see cref="TypedMetadataData{TMetadata}"/> 
+        /// instances where the <code>ObjectData</code> type has attributes that are defined in 
+        /// <seealso cref="Options.OptionMetadata"/> but no corresponding entry in <seealso cref="serializations"/>
+        /// exists.
+        /// </remarks>
+        private void PreSerializationAdjustments()
+        {
+            // This is a list of all the typed metadata instances.
+            var typedMetadataData =
+                this.serializations.Get<TypedMetadataData>()
+                    .ToList();
+
+            // This is a list of all the typed object data instances.
+            var typedObjectData =
+                this.serializations.Get<TypedObjectData>()
+                    .ToList();
+
+            // There should be a TypedMetadataData serialization for each `typedObjectData`
+            // instance that has an attribute with a type that is included in the option metadata.
+            // Create a virtual list of all the expected metadata serializations and remove all
+            // those that already exist; this will leave just those that are missing.
+            var objectDataMetadataTypes =
+                GetObjectTypeMetadataTypeCombinations(typedObjectData, typedMetadataData);
+
+            // So for each object type insert before it appropriate serializations for the metadata 
+            // types from `objectDataMetadataTypes`.
+            AddMetadataSerializations(objectDataMetadataTypes, typedObjectData);
         }
 
-        /// <inheritdoc/>
-        public string Serialize()
-        {
-            List<string> list = new();
+        /// <summary>
+        /// Serialize the <seealso cref="serializations"/> preceeded by the specified <paramref name="preceedingData"/> 
+        /// data to a <see cref="string[]"/>.
+        /// </summary>
+        /// <param name="preceedingData">A <see cref="string[]"/> containing data that is to be included before the <seealso cref="serializations"/> data.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] ToArray(string[] preceedingData) =>
+            new List<string[]> { preceedingData, this.ToArray(), }
+                .SelectMany(items => items)
+                .ToArray();
 
-            foreach (var serialization in this.serializations)
-                list.AddRange(serialization.Serialize());
-
-            var text = string.Join(Environment.NewLine, list);
-            return text;
-        }
+        /// <summary>
+        /// Serializes the <seealso cref="serializations"/> to a <see cref="string[]"/>.
+        /// </summary>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] ToArray() =>
+            this.serializations
+                .Select(serialization => serialization.Serialize())
+                .SelectMany(lines => lines)
+                .ToArray();
 
         #endregion
 
         #region Nested classes
 
         /// <summary>
-        /// The abstract base class for holding data to be serialized.
+        /// Sealed factory class to allow the dynamic provision of data from a <see cref="Serialization"/>
+        /// object.
         /// </summary>
-        private abstract class BaseSerializationData
+        internal sealed class SerializationFactory
         {
-            /// <summary>
-            /// Serialize the data held in the current instance.
-            /// </summary>
-            /// <returns>A <see cref="string"/> containing the result of the serialization.</returns>
-            public abstract string[] Serialize();
-        }
-
-        /// <summary>
-        /// A sealed class for holding blank line data.
-        /// </summary>
-        private sealed class BlankLinesData : BaseSerializationData
-        {
-            private readonly int number;
-
-            public BlankLinesData(int number) => this.number = number;
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                Enumerable
-                    .Range(0, this.number)
-                    .Select(_ => string.Empty)
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// A sealed class for serializing comments.
-        /// </summary>
-        private sealed class CommentData : BaseSerializationData
-        {
-            private readonly string prefix;
-            private readonly string[] comments;
-
-            public CommentData(string prefix, params string[] comments)
-            {
-                this.prefix = prefix;
-                this.comments =
-                    !comments.Any()
-                    ? new [] { string.Empty, }
-                    : comments
-                        // Split using `\r\n` CharArray rather than `Environment.NewLine` to cater
-                        // for files that use a differnet standard from the current OS.
-                        // Don't trim the resultant comments to allow them to have leading spaces.
-                        .Select(comment => comment.Split("\r\n".ToCharArray(),
-                                                         StringSplitOptions.RemoveEmptyEntries))
-                        .SelectMany(comment => comment)
-                        .ToArray();
-            }
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                this.comments
-                    .Select(comment => $"{prefix} {comment}")
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// An abstract base class for serializing config data.
-        /// </summary>
-        private abstract class BaseConfigData : BaseSerializationData
-        {
-            protected Dictionary<string, string> Configuration { get; }
-
-            protected abstract Lazy<string[]> ValidKeys { get; }
-
-            protected BaseConfigData(Dictionary<string, string> configuration) =>
-                this.Configuration = configuration;
-
-            protected IEnumerable<KeyValuePair<string, string>> GetConfiguration() =>
-                this.Configuration
-                    .Where(kvp => this.ValidKeys.Value.Any(key => key == kvp.Key));
-
-            protected static string[] GetValidKeys(Type type) =>
-                type.GetFields(BindingFlags.Public |
-                                BindingFlags.Static)
-                    .Where(field => field.FieldType == typeof(string))
-                    .Select(field => field.GetValue(null))
-                    .Cast<string>()
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// A sealed class for serializing global config data.
-        /// </summary>
-        private sealed class GlobalConfigData : BaseConfigData
-        {
-            private readonly string prefix = Converter.Keys.GlobalConfig.GlobalConfigPrefix;
-
-            protected override Lazy<string[]> ValidKeys { get; } =
-                new(() => GetValidKeys(typeof(Converter.Keys.GlobalConfig)));
-
-            public GlobalConfigData(Dictionary<string, string> configuration)
-                : base(configuration) { }
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                GetConfiguration()
-                    .Select(kvp => $"{this.prefix},{kvp.Key},{kvp.Value}")
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// A sealed class for serializing typed config data.
-        /// </summary>
-        private sealed class TypedConfigData : BaseConfigData
-        {
-            private readonly string prefix = Converter.Keys.TypedConfig.TypedConfigPrefix;
-            private readonly string typeName;
-
-            protected override Lazy<string[]> ValidKeys { get; } =
-                new(() => GetValidKeys(typeof(Converter.Keys.TypedConfig)));
-
-            public TypedConfigData(string typeName, Dictionary<string, string> configuration)
-                : base(configuration) => this.typeName = typeName;
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                GetConfiguration()
-                    .Select(kvp => $"{this.prefix},{this.typeName},{kvp.Key},{kvp.Value}")
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// An abstract base class for serializing conversion data.
-        /// </summary>
-        private abstract class BaseConversionData : BaseSerializationData
-        {
-            private readonly string prefix;
-            private readonly Dictionary<string, string> conversion;
-
-            protected BaseConversionData(string prefix, Dictionary<string, string> conversion)
-            {
-                this.prefix = prefix;
-                this.conversion = conversion;
-            }
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                this.conversion
-                    .Select(kvp => $"{this.prefix},\"{kvp.Key}\",\"{kvp.Value}\"")
-                    .ToArray();
-        }
-
-        /// <summary>
-        /// A sealed class for serializing type conversion data.
-        /// </summary>
-        private sealed class TypeConversionData : BaseConversionData
-        {
-            public TypeConversionData(Dictionary<string, string> typeConversion)
-                : base(ConfigHandler.Configurations.ConversionTypePrefix, typeConversion) { }
-        }
-
-        /// <summary>
-        /// A sealed class for serializing value conversion data.
-        /// </summary>
-        private sealed class ValueConversionData : BaseConversionData
-        {
-            public ValueConversionData(Dictionary<string, string> valueConversion)
-                : base(ConfigHandler.Configurations.ConversionValuePrefix, valueConversion) { }
-        }
-
-        /// <summary>
-        /// An abstract base class for serializing metadata.
-        /// </summary>
-        private abstract class BaseMetadataData : BaseSerializationData
-        {
-            /// <summary>
-            /// The name of the type of the object data that this metadata is attached to.
-            /// </summary>
-            protected readonly string dataTypeName;
+            private readonly Serialization serialization;
 
             /// <summary>
-            /// The prefix to use to identify this metadata.
+            /// Gets the <see cref="Options"/> associated with the current instance.
             /// </summary>
-            protected readonly string metadataPrefix;
+            internal Options Options => this.serialization.Options;
+
+            private IEnumerable<BaseSerializationData> Serializations => this.serialization.serializations;
+
+            public SerializationFactory(Serialization serialization) => this.serialization = serialization;
 
             /// <summary>
-            /// The names of the properties of the metadata in the order that they are to be serialized.
+            /// Gets the Metadata Type Names.
             /// </summary>
-            protected readonly string[]? propertyNames;
-
-            protected BaseMetadataData(string dataTypeName, string metadataPrefix, string[]? propertyNames)
-            {
-                this.dataTypeName = dataTypeName;
-                this.metadataPrefix = metadataPrefix;
-                this.propertyNames = propertyNames;
-            }
-        }
-
-        /// <summary>
-        /// A sealed class for serializing typed metadata of <typeparamref name="TMetadata"/>.
-        /// </summary>
-        /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
-        private sealed class TypedMetadataData<TMetadata> : BaseMetadataData
-            where TMetadata : class
-        {
-            private readonly IEnumerable<TMetadata> metadata;
-            private readonly PropertyInfo[] properties;
-
-            public TypedMetadataData(string dataTypeName, string prefix, string[]? propertyNames, IEnumerable<TMetadata> metadata)
-                : base(dataTypeName, prefix, propertyNames)
-            {
-                this.metadata = metadata;
-
-                this.properties =
-                    typeof(TMetadata).GetProperties(BindingFlags.Instance |
-                                                    BindingFlags.Public)
-                        .Where(property => property.CanRead && property.CanWrite)
-                        .Where(property => this.propertyNames?.Contains(property.Name) ?? false)
-                        .ToArray();
-            }
-
-            public override string[] Serialize() => 
-                this.metadata
-                    .Select(md => GetValues(md))
-                    .Where(values => !string.IsNullOrWhiteSpace(values))
-                    .Select(values => $"{this.metadataPrefix},{this.dataTypeName},{values}")
+            /// <typeparam name="T">A <see cref="Type"/> to use to restrict to either typed or typeless metadata.</typeparam>
+            /// <returns>A <see cref="string[]"/>.</returns>
+            public string[] GetMetadataTypeNames<T>() where T : BaseMetadataData =>
+                this.Serializations
+                    .Where(serialization => serialization.GetType().IsAssignableTo(typeof(T)))
+                    .Select(serialization => serialization as T)
+                    .NotNull()
+                    .Select(metadataSerialization => metadataSerialization.MetadataTypeName)
                     .ToArray();
 
-            private string GetValues(TMetadata metadata)
-            {
-                if (this.propertyNames is null)
-                    return string.Empty;
+            /// <summary>
+            /// Gets the Property Prefix for the specified <paramref name="typeName"/>.
+            /// </summary>
+            /// <param name="typeName">A <see cref="string"/> that contains the type name.</param>
+            /// <returns>A <see cref="string"/>.</returns>
+            public string GetPropertyPrefix(string typeName) =>
+                ConfigHelper.GetPropertyPrefix(
+                    GetGlobalConfig(),
+                    GetTypedConfig(),
+                    this.Options,
+                    typeName);
 
-                // The values must be in the order defined in the Options Metadata,
-                // so derive them from the Options Metadata PropertyNames,
-                // rather than directly from the properties of the Type.
+            /// <summary>
+            /// Gets the Value Prefix for the specified <paramref name="typeName"/>.
+            /// </summary>
+            /// <param name="typeName">A <see cref="string"/> that contains the type name.</param>
+            /// <returns>A <see cref="string"/>.</returns>
+            public string GetvaluePrefix(string typeName) =>
+                ConfigHelper.GetValuePrefix(
+                    GetGlobalConfig(),
+                    GetTypedConfig(),
+                    this.Options,
+                    typeName);
 
-                var properties =
-                    this.propertyNames
-                        .Select(propertyName =>
-                            this.properties
-                                .FirstOrDefault(property => property.Name == propertyName))
-                        .NotNull()
-                        .ToArray();
-                if (properties is null)
-                    return string.Empty;
+            /// <summary>
+            /// Gets the Global Config data from the <seealso cref="serialization"/> object.
+            /// </summary>
+            /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IGlobalConfig"/> objects.</returns>
+            private IEnumerable<IGlobalConfig> GetGlobalConfig() =>
+                this.Serializations
+                    .Select(s => s as GlobalConfigData)
+                    .NotNull()
+                    .SelectMany(item => item);
 
-                var results =
-                    ConverterHelper.AsStrings(metadata, properties)
-                        .ToArray();
-
-                var result = string.Join(",", results);
-
-                return result;
-            }
-        }
-
-        /// <summary>
-        /// A sealed class for serializing typeless metadata.
-        /// </summary>
-        private sealed class TypelessMetadataData : BaseMetadataData
-        {
-            private readonly Dictionary<string, string> metadata;
-
-            public TypelessMetadataData(string dataTypeName, string metadataPrefix, string[]? propertyNames, Dictionary<string, string> metadata)
-                : base(dataTypeName, metadataPrefix, propertyNames) => this.metadata = metadata;
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                new[] { $"{this.metadataPrefix},{this.dataTypeName},{GetValues()}" };
-
-            private string GetValues()
-            {
-                var results = this.propertyNames is null ?
-                    Array.Empty<string>() :
-                    this.propertyNames
-                        .Select(propertyName =>
-                            this.metadata.TryGetValue(propertyName, out var value)
-                                ? value
-                                : string.Empty)
-                        .Select(value => $"\"{value}\"")
-                        .ToArray();
-
-                var result = string.Join(",", results);
-
-                return result;
-            }
-        }
-
-        /// <summary>
-        /// An abstract base class for serializing data.
-        /// </summary>
-        private abstract class BaseDataData : BaseSerializationData
-        {
-            #region Fields
-
-            protected readonly string propertyPrefix;
-            protected readonly string valuePrefix;
-            protected readonly string typeName;
-
-            #endregion
-
-            #region Abstract properties
-
-            protected abstract string[] Names { get; }
-
-            #endregion
-
-            #region Constructors
-
-            protected BaseDataData(string propertyPrefix, string valuePrefix, string typeName)
-            {
-                this.propertyPrefix = propertyPrefix;
-                this.valuePrefix = valuePrefix;
-                this.typeName = typeName;
-            }
-
-            #endregion
-
-            #region Overrides
-
-            /// <inheritdoc/>
-            public override string[] Serialize() =>
-                GetNames()
-                    .Union(GetValues())
-                    .ToArray();
-
-            #endregion
-
-            #region Abstract support routines
-
-            protected abstract string[] GetValues();
-
-            #endregion
-
-            #region Support routines
-
-            private string[] GetNames() =>
-                new[] { ConverterHelper.FormatCsvData(this.propertyPrefix, this.typeName, this.Names), };
-
-            #endregion
-        }
-
-        /// <summary>
-        /// A sealed class for serializing data of <typeparamref name="TObject"/>.
-        /// </summary>
-        /// <typeparam name="TObject">The type of the data.</typeparam>
-        private sealed class TypedDataData<TObject> : BaseDataData
-            where TObject : class
-        {
-            #region Fields
-
-            private readonly IEnumerable<TObject> data;
-            private readonly PropertyInfo[]? properties;
-            private readonly string[] names;
-
-            #endregion
-
-            #region Override properties
-
-            protected override string[] Names => this.names;
-
-            #endregion
-
-            #region Constructors
-
-            public TypedDataData(string propertyPrefix, string valuePrefix, string typeName, IEnumerable<TObject> data)
-                : base(propertyPrefix, valuePrefix, typeName)
-            {
-                this.data = data;
-                this.properties =
-                    typeof(TObject).GetProperties(BindingFlags.Instance |
-                                                  BindingFlags.Public)
-                        .Where(property => property.CanRead && property.CanWrite)
-                        .ToArray();
-                this.names = GetNames();
-            }
-
-            #endregion
-
-            #region Overrides
-
-            protected override string[] GetValues() =>
-                this.data
-                    .Select(item => GetValues(item))
-                    .Where(values => values.Any())
-                    .Where(values => values.Length == this.names.Length)
-                    .Select(values => ConverterHelper.FormatCsvData(this.valuePrefix, this.typeName, values))
-                    .ToArray();
-
-            #endregion
-
-            #region Support routines
-
-            private string[] GetNames() =>
-                this.properties is null ?
-                    Array.Empty<string>() :
-                    this.properties
-                        .Select(property => property.Name)
-                        .ToArray();
-
-            private string[] GetValues(TObject item) =>
-                this.properties is null ?
-                    Array.Empty<string>() :
-                    ConverterHelper.AsStrings(item, this.properties)
-                        .ToArray();
-
-            #endregion
-        }
-
-        /// <summary>
-        /// A sealed class for serializing typeless data.
-        /// </summary>
-        private sealed class TypelessDataData : BaseDataData
-        {
-            #region Fields
-
-            private readonly IEnumerable<string[]> values;
-
-            #endregion
-
-            #region Override properties
-
-            protected override string[] Names { get; }
-
-            #endregion
-
-            #region Constructors
-
-            public TypelessDataData(string propertyPrefix, string valuePrefix, string typeName, string[] names, IEnumerable<string[]> values)
-                : base(propertyPrefix, valuePrefix, typeName)
-            {
-                this.Names = names;
-                this.values = values;
-            }
-
-            #endregion
-
-            #region Overrides
-
-            protected override string[] GetValues() =>
-                this.values
-                    .Select(values => GetValues(values))
-                    .Select(values => ConverterHelper.FormatCsvData(this.valuePrefix, this.typeName, values))
-                    .ToArray();
-
-            #endregion
-
-            #region Support routines
-
-            private static string[] GetValues(string[] values) =>
-                values
-                    .Select(value => $"\"{value}\"")
-                    .ToArray();
-
-            #endregion
+            /// <summary>
+            /// Gets the Typed Config data from the <seealso cref="serialization"/> object.
+            /// </summary>
+            /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ITypedConfig"/> objects.</returns>
+            private IEnumerable<ITypedConfig> GetTypedConfig() =>
+                this.Serializations
+                    .Select(s => s as TypedConfigData)
+                    .NotNull()
+                    .SelectMany(item => item);
         }
 
         #endregion

--- a/Crowswood.CsvConverter/Serializations/BaseSerializationData.cs
+++ b/Crowswood.CsvConverter/Serializations/BaseSerializationData.cs
@@ -1,0 +1,14 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// The abstract base class for holding data to be serialized.
+    /// </summary>
+    public abstract class BaseSerializationData
+    {
+        /// <summary>
+        /// Serialize the data held in the current instance.
+        /// </summary>
+        /// <returns>A <see cref="string"/> containing the result of the serialization.</returns>
+        public abstract string[] Serialize();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/BlankLinesData.cs
+++ b/Crowswood.CsvConverter/Serializations/BlankLinesData.cs
@@ -1,0 +1,20 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for holding blank line data.
+    /// </summary>
+    internal sealed class BlankLinesData : BaseSerializationData
+    {
+        private readonly int number;
+
+        public BlankLinesData(int number) => this.number = number;
+
+        /// <inheritdoc/>
+        public override string[] Serialize() =>
+            Enumerable
+                .Range(0, this.number)
+                .Select(_ => string.Empty)
+                .ToArray();
+    }
+
+}

--- a/Crowswood.CsvConverter/Serializations/CommentData.cs
+++ b/Crowswood.CsvConverter/Serializations/CommentData.cs
@@ -1,0 +1,34 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing comments.
+    /// </summary>
+    internal sealed class CommentData : BaseSerializationData
+    {
+        private readonly string prefix;
+        private readonly string[] comments;
+
+        public CommentData(string prefix, params string[] comments)
+        {
+            this.prefix = prefix;
+            this.comments =
+                !comments.Any()
+                ? new[] { string.Empty, }
+                : comments
+                    // Split using `\r\n` CharArray rather than `Environment.NewLine` to cater
+                    // for files that use a differnet standard from the current OS.
+                    // Don't trim the resultant comments to allow them to have leading spaces.
+                    .Select(comment => comment.Split("\r\n".ToCharArray(),
+                                                     StringSplitOptions.RemoveEmptyEntries))
+                    .SelectMany(comment => comment)
+                    .ToArray();
+        }
+
+        /// <inheritdoc/>
+        public override string[] Serialize() =>
+            this.comments
+                .Select(comment => $"{prefix} {comment}")
+                .ToArray();
+    }
+
+}

--- a/Crowswood.CsvConverter/Serializations/Config/BaseConfigData.cs
+++ b/Crowswood.CsvConverter/Serializations/Config/BaseConfigData.cs
@@ -1,0 +1,20 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+
+    /// <summary>
+    /// An abstract base class for serializing config data.
+    /// </summary>
+    internal abstract class BaseConfigData : BaseSerializationData
+    {
+        protected Dictionary<string, string> Configuration { get; }
+
+        protected abstract Lazy<string[]> ValidKeys { get; }
+
+        protected BaseConfigData(Dictionary<string, string> configuration) =>
+            this.Configuration = configuration;
+
+        protected IEnumerable<KeyValuePair<string, string>> GetConfiguration() =>
+            this.Configuration
+                .Where(kvp => this.ValidKeys.Value.Any(key => key == kvp.Key));
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Config/GlobalConfigData.cs
+++ b/Crowswood.CsvConverter/Serializations/Config/GlobalConfigData.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections;
+using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Interfaces;
+using Crowswood.CsvConverter.UserConfig;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing global config data.
+    /// </summary>
+    internal sealed class GlobalConfigData : BaseConfigData,
+        IEnumerable<IGlobalConfig>
+    {
+        private readonly string prefix = Converter.Keys.GlobalConfig.GlobalConfigPrefix;
+
+        protected override Lazy<string[]> ValidKeys { get; } =
+            new(() => ConfigHelper.GetValidConfigKeys(typeof(Converter.Keys.GlobalConfig)));
+
+        public GlobalConfigData(Dictionary<string, string> configuration)
+            : base(configuration) { }
+
+        /// <inheritdoc/>
+        public override string[] Serialize() =>
+            GetConfiguration()
+                .Select(kvp => $"{this.prefix},{kvp.Key},{kvp.Value}")
+                .ToArray();
+
+        IEnumerator<IGlobalConfig> IEnumerable<IGlobalConfig>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private IEnumerator<IGlobalConfig> GetEnumerator() =>
+            this.Configuration
+                .Select(config => new GlobalConfig(config.Key, config.Value))
+                .GetEnumerator();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Config/TypedConfigData.cs
+++ b/Crowswood.CsvConverter/Serializations/Config/TypedConfigData.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using Crowswood.CsvConverter.Helpers;
+using Crowswood.CsvConverter.Interfaces;
+using Crowswood.CsvConverter.UserConfig;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing typed config data.
+    /// </summary>
+    internal sealed class TypedConfigData : BaseConfigData,
+        IEnumerable<ITypedConfig>
+    {
+        private readonly string prefix = Converter.Keys.TypedConfig.TypedConfigPrefix;
+        private readonly string typeName;
+
+        protected override Lazy<string[]> ValidKeys { get; } =
+            new(() => ConfigHelper.GetValidConfigKeys(typeof(Converter.Keys.TypedConfig)));
+
+        public TypedConfigData(string typeName, Dictionary<string, string> configuration)
+            : base(configuration) => this.typeName = typeName;
+
+        /// <inheritdoc/>
+        public override string[] Serialize() =>
+            GetConfiguration()
+                .Select(kvp => $"{this.prefix},{this.typeName},{kvp.Key},{kvp.Value}")
+                .ToArray();
+
+        IEnumerator<ITypedConfig> IEnumerable<ITypedConfig>.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        private IEnumerator<ITypedConfig> GetEnumerator()=>
+            this.Configuration
+                .Select(config => new TypedConfig(this.typeName, config.Key, config.Value))
+                .GetEnumerator();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Conversion/BaseConversionData.cs
+++ b/Crowswood.CsvConverter/Serializations/Conversion/BaseConversionData.cs
@@ -1,0 +1,23 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstract base class for serializing conversion data.
+    /// </summary>
+    internal abstract class BaseConversionData : BaseSerializationData
+    {
+        private readonly string prefix;
+        private readonly Dictionary<string, string> conversion;
+
+        protected BaseConversionData(string prefix, Dictionary<string, string> conversion)
+        {
+            this.prefix = prefix;
+            this.conversion = conversion;
+        }
+
+        /// <inheritdoc/>
+        public override string[] Serialize() =>
+            this.conversion
+                .Select(kvp => $"{this.prefix},\"{kvp.Key}\",\"{kvp.Value}\"")
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Conversion/TypeConversionData.cs
+++ b/Crowswood.CsvConverter/Serializations/Conversion/TypeConversionData.cs
@@ -1,0 +1,13 @@
+﻿using Crowswood.CsvConverter.Handlers;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing type conversion data.
+    /// </summary>
+    internal sealed class TypeConversionData : BaseConversionData
+    {
+        public TypeConversionData(Dictionary<string, string> typeConversion)
+            : base(ConfigHandler.Configurations.ConversionTypePrefix, typeConversion) { }
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Conversion/ValueConversionData.cs
+++ b/Crowswood.CsvConverter/Serializations/Conversion/ValueConversionData.cs
@@ -1,0 +1,13 @@
+﻿using Crowswood.CsvConverter.Handlers;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing value conversion data.
+    /// </summary>
+    internal sealed class ValueConversionData : BaseConversionData
+    {
+        public ValueConversionData(Dictionary<string, string> valueConversion)
+            : base(ConfigHandler.Configurations.ConversionValuePrefix, valueConversion) { }
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
@@ -1,0 +1,31 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstract base class for serializing metadata.
+    /// </summary>
+    internal abstract class BaseMetadataData : BaseSerializationData
+    {
+        protected readonly Serialization.SerializationFactory prefixFactory;
+
+        /// <summary>
+        /// The name of the type of the object data that this metadata is attached to.
+        /// </summary>
+        protected readonly string dataTypeName;
+
+        /// <summary>
+        /// The name of the type of the metadata.
+        /// </summary>
+        internal abstract string MetadataTypeName { get; }
+
+        /// <summary>
+        /// Gets the name of the object data type that this metadata is attached to.
+        /// </summary>
+        internal string ObjectDataTypeName => this.dataTypeName;
+
+        protected BaseMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName)
+        {
+            this.prefixFactory = prefixFactory;
+            this.dataTypeName = dataTypeName;
+        }
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Metadata/TypedMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/TypedMetadataData.cs
@@ -1,0 +1,179 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Helpers;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstact class that provides the base class for the generic typed metadata variants.
+    /// </summary>
+    internal abstract class TypedMetadataData : BaseMetadataData
+    {
+        /// <summary>
+        /// Gets the type of metadata that the current instance serializes.
+        /// </summary>
+        public abstract Type MetadataType { get; }
+
+        protected TypedMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName)
+            : base(prefixFactory, dataTypeName) { }
+
+        /// <summary>
+        /// Creates and returns an instance of <see cref="TypedMetadataData{TMetadata}"/> for the 
+        /// specified <paramref name="metadataType"/> using the specified <paramref name="serialization"/> 
+        /// and <paramref name="dataTypeName"/> that serializes the specified <paramref name="metadata"/>.
+        /// </summary>
+        /// <param name="metadataType">A <see cref="Type"/> that defines the type of the metadata.</param>
+        /// <param name="serialization">The <see cref="Serialization"/> instance that the new instance will belong to.</param>
+        /// <param name="dataTypeName">A <see cref="string"/> that contains the name of the data object type.</param>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/> that contains the metadata; each element must be able to be assigned to <paramref name="metadataType"/>.</param>
+        /// <returns>A <see cref="TypedMetadataData"/> instance.</returns>
+        /// <exception cref="InvalidOperationException">If an instance cannot be created.</exception>
+        /// <remarks>
+        /// Calls <seealso cref="Create{TMetadata}(Serialization.SerializationFactory, string, IEnumerable{object})"/>
+        /// by reflection.
+        /// </remarks>
+        internal static TypedMetadataData Create(Type metadataType,
+                                                 Serialization serialization,
+                                                 string dataTypeName,
+                                                 IEnumerable<object> metadata)
+        {
+            var parameters =
+                new object[]
+                {
+                    new Serialization.SerializationFactory(serialization),
+                    dataTypeName,
+                    metadata,
+                };
+
+            var method =
+                typeof(TypedMetadataData).GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                    .Where(method => method.Name == "Create")
+                    .Where(method => method.IsGenericMethod)
+                    .SingleOrDefault()?.MakeGenericMethod(metadataType);
+
+            var result =
+                method?.Invoke(null, parameters) ??
+                throw new InvalidOperationException(
+                    $"Failed to bind to {nameof(TypedMetadataData)}<{metadataType.Name}>.");
+
+            return (TypedMetadataData)result;
+        }
+
+        /// <summary>
+        /// Creates and returns an instance of <see cref="TypedMetadataData{TMetadata}"/> for the 
+        /// specified <typeparamref name="TMetadata"/> using the specified <paramref name="factory"/>, 
+        /// and <paramref name="dataTypeName"/> that serializes the specified <paramref name="metadata"/>.
+        /// </summary>
+        /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
+        /// <param name="factory">A <see cref="Serialization.SerializationFactory"/> object.</param>
+        /// <param name="dataTypeName">A <see cref="string"/> that contains the name of the data object type.</param>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/> that contains the metadata; each element must be able to be assigned to <paramref name="metadataType"/>.</param>
+        /// <returns>A <see cref="TypedMetadataData"/> instance.</returns>
+        /// <remarks>
+        /// Method is called using reflection by <seealso cref="Create(Type, Serialization, string, IEnumerable{object})"/>
+        /// </remarks>
+        private static TypedMetadataData Create<TMetadata>(Serialization.SerializationFactory factory,
+                                                           string dataTypeName,
+                                                           IEnumerable<object> metadata)
+            where TMetadata : class
+        {
+            var typedMetadata =
+                metadata
+                    .Where(md => md.GetType().IsAssignableTo(typeof(TMetadata)))
+                    .Cast<TMetadata>()
+                    .ToList();
+
+            var result =
+                new TypedMetadataData<TMetadata>(factory, dataTypeName, typedMetadata);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// A sealed class for serializing typed metadata of <typeparamref name="TMetadata"/>.
+    /// </summary>
+    /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
+    internal sealed class TypedMetadataData<TMetadata> : TypedMetadataData
+        where TMetadata : class
+    {
+        private readonly IEnumerable<TMetadata> metadata;
+
+        internal override string MetadataTypeName => typeof(TMetadata).Name;
+
+        public override Type MetadataType => typeof(TMetadata);
+
+        public TypedMetadataData(Serialization.SerializationFactory factory, string dataTypeName, IEnumerable<TMetadata> metadata)
+            : base(factory, dataTypeName) => this.metadata = metadata;
+
+        /// <inheritdoc/>
+        public override string[] Serialize()
+        {
+            var metadataType = typeof(TMetadata);
+            var optionMetadata =
+                this.prefixFactory.Options.GetOptionMetadata(metadataType) ??
+                throw new InvalidOperationException(
+                    $"No Metadata definition in Options for '{metadataType.Name}'.");
+
+            var properties = GetProperties<TMetadata>(optionMetadata.PropertyNames);
+            var result =
+                Serialize(
+                    optionMetadata.Prefix, 
+                    GetProperties(properties, optionMetadata.PropertyNames));
+            return result;
+        }
+
+        /// <summary>
+        /// Serializes the <seealso cref="metadata"/> using the specified <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] Serialize(string metadataPrefix, PropertyInfo[] properties) =>
+            this.metadata
+                .Select(metadata => ConverterHelper.AsStrings(metadata, properties).ToArray())
+                .Where(values => values.Any())
+                .Select(values => values.AsCsv(metadataPrefix, this.dataTypeName))
+                .ToArray();
+
+        /// <summary>
+        /// Gets the <see cref="PropertyInfo"/> from <typeparamref name="T"/> that exist in the 
+        /// specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="MetadataType"/> to get the properties of.</typeparam>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        private static PropertyInfo[] GetProperties<T>(string[] propertyNames) => 
+            GetProperties(typeof(T), propertyNames);
+
+        /// <summary>
+        /// Gets the <see cref="PropertyInfo"/> from the specified <paramref name="type"/> that 
+        /// exist in the specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="MetadataType"/> to get the properties of.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        private static PropertyInfo[] GetProperties(Type type, string[] propertyNames) =>
+            type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(property => property.CanRead && property.CanWrite)
+                .Where(property => propertyNames?.Contains(property.Name) ?? false)
+                .ToArray();
+
+        /// <summary>
+        /// Gets the <see cref="PropertyInfo"/> from the specified <paramref name="properties"/> 
+        /// according to the order defined in the specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> contains the names of the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        /// <remarks>
+        /// The values must be in the order defined in the Options Metadata, so derive them from 
+        /// the PropertyNames, rather than directly from the properties of the Type.
+        /// </remarks>
+        private static PropertyInfo[] GetProperties(PropertyInfo[] properties, string[] propertyNames) =>
+            propertyNames
+                .Select(propertyName =>
+                    properties
+                        .FirstOrDefault(property => property.Name == propertyName))
+                .NotNull()
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
@@ -1,0 +1,61 @@
+﻿using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing typeless metadata.
+    /// </summary>
+    internal sealed class TypelessMetadataData : BaseMetadataData
+    {
+        private readonly string metadataPrefix;
+        private readonly Dictionary<string, string> metadata;
+
+        internal override string MetadataTypeName => this.metadataPrefix;
+
+        public TypelessMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata)
+            : base(prefixFactory, dataTypeName)
+        {
+            this.metadataPrefix = metadataPrefix;
+            this.metadata = metadata;
+        }
+
+        /// <inheritdoc/>
+        public override string[] Serialize()
+        {
+            var optionMetadata =
+                this.prefixFactory.Options.GetOptionMetadata(metadataPrefix) ??
+                throw new InvalidOperationException(
+                    $"No Metadata definition in Options for a prefix of '{metadataPrefix}'.");
+
+            var result = 
+                GetValues(this.metadata, optionMetadata.PropertyNames)
+                    .AsCsv(optionMetadata.Prefix, this.dataTypeName);
+
+            return new[] { result, };
+        }
+
+        /// <summary>
+        /// Gets the property values from the specified <paramref name="metadata"/> dictionary 
+        /// using the specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the metadata.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetValues(Dictionary<string, string> metadata, string[] propertyNames) =>
+            propertyNames
+                .Select(propertyName => Getvalue(metadata, propertyName))
+                .Select(value => $"\"{value}\"")
+                .ToArray();
+
+        /// <summary>
+        /// Gets a value from the specified <paramref name="propertyName"/> using the specified 
+        /// <paramref name="propertyName"/> or empty string if the metadata does not contain an 
+        /// item with the property name.
+        /// </summary>
+        /// <param name="metadata">A <see cref="Dictionary{TKey, TValue}"/> of <see cref="string"/> keyed by <see cref="string"/> containing the metadata.</param>
+        /// <param name="propertyName">A <see cref="string"/> containing the property name.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        private static string Getvalue(Dictionary<string, string> metadata, string propertyName) =>
+            metadata.TryGetValue(propertyName, out var value) ? value : string.Empty;
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/ObjectData/BaseObjectData.cs
+++ b/Crowswood.CsvConverter/Serializations/ObjectData/BaseObjectData.cs
@@ -1,0 +1,64 @@
+﻿using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstract base class for serializing object data.
+    /// </summary>
+    internal abstract class BaseObjectData : BaseSerializationData
+    {
+        protected readonly string typeName;
+        protected readonly Serialization.SerializationFactory factory;
+
+        /// <summary>
+        /// Gets the names.
+        /// </summary>
+        protected abstract string[] Names { get; }
+
+        protected BaseObjectData(Serialization.SerializationFactory factory, string typeName)
+        {
+            this.factory = factory;
+            this.typeName = typeName;
+        }
+
+        /// <inheritdoc/>
+        public override string[] Serialize() => Serialize(GetValuePrefix());
+
+        /// <summary>
+        /// Gets the values using the specified <paramref name="valuePrefix"/> with one element 
+        /// per record.
+        /// </summary>
+        /// <param name="valuePrefix">A <see cref="string"/> containing the value prefix.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        protected abstract string[] GetValues(string valuePrefix);
+
+        /// <summary>
+        /// Gets the value prefix.
+        /// </summary>
+        protected string GetValuePrefix() => this.factory.GetvaluePrefix(this.typeName);
+
+        /// <summary>
+        /// Gets the names as a <see cref="string[]"/> with only one element.
+        /// </summary>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] GetNames() => GetNames(this.factory.GetPropertyPrefix(this.typeName));
+
+        /// <summary>
+        /// Gets the names as a string with only one element using the specified <paramref name="propertyPrefix"/>.
+        /// </summary>
+        /// <param name="propertyPrefix">A <see cref="string"/> containing the property prefix.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] GetNames(string propertyPrefix) =>
+            new[] { this.Names.AsCsv(propertyPrefix, this.typeName), }; 
+
+        /// <summary>
+        /// Serialize the data using the specified <paramref name="valuePrefix"/>.
+        /// </summary>
+        /// <param name="valuePrefix">A <see cref="string"/> containing the value prefix.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] Serialize(string valuePrefix) =>
+            new List<string[]> { GetNames(), GetValues(valuePrefix), }
+                .SelectMany(items => items)
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/ObjectData/TypedObjectData.cs
+++ b/Crowswood.CsvConverter/Serializations/ObjectData/TypedObjectData.cs
@@ -1,0 +1,91 @@
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Helpers;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstract class for serializing typed object data.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="TypedObjectData{TObject}"/> for actual instances.
+    /// </remarks>
+    internal abstract class TypedObjectData : BaseObjectData
+    {
+        /// <summary>
+        /// Gets the type that the current instance serializes.
+        /// </summary>
+        public abstract Type Type { get; }
+
+        protected TypedObjectData(Serialization.SerializationFactory factory, string typeName)
+            : base(factory, typeName) { }
+    }
+
+    /// <summary>
+    /// A sealed class for serializing data of <typeparamref name="TObject"/>.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the data.</typeparam>
+    internal sealed class TypedObjectData<TObject> : TypedObjectData
+        where TObject : class
+    {
+        private readonly IEnumerable<TObject> data;
+        private readonly PropertyInfo[] properties;
+
+        /// <inheritdoc/>
+        protected override string[] Names { get; }
+
+        /// <inheritdoc/>
+        public override Type Type => typeof(TObject);
+
+        public TypedObjectData(Serialization.SerializationFactory factory, string typeName, IEnumerable<TObject> data)
+            : base(factory, typeName)
+        {
+            this.data = data;
+            this.properties = GetProperties(typeof(TObject));
+            this.Names = GetNames(this.properties);
+        }
+
+        /// <inheritdoc/>
+        protected override string[] GetValues(string valuePrefix) =>
+            this.data
+                .Select(item => TypedObjectData<TObject>.GetValues(item, this.properties))
+                .Where(values => values.Any())
+                .Where(values => values.Length == this.Names.Length)
+                .Select(values => values.AsCsv(valuePrefix, this.typeName))
+                .ToArray();
+
+        /// <summary>
+        /// Gets the names from the specified <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetNames(PropertyInfo[] properties) =>
+            properties
+                .GetPropertyAndAttributePairs()
+                .GetPropertyAndNamePairs()
+                .Select(item => item.Name)
+                .ToArray();
+
+        /// <summary>
+        /// Gets public instance properties from the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        private static PropertyInfo[] GetProperties(Type type) =>
+            type.GetProperties(BindingFlags.Instance |
+                               BindingFlags.Public)
+                .Where(property => property.CanRead && property.CanWrite)
+                .ToArray();
+
+        /// <summary>
+        /// Gets the property values of the specified <paramref name="item"/> using the specified 
+        /// <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="item">A <typeparamref name="TObject"/> object.</param>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetValues(TObject item, PropertyInfo[] properties) =>
+            ConverterHelper.AsStrings(item, properties)
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/ObjectData/TypelessObjectData.cs
+++ b/Crowswood.CsvConverter/Serializations/ObjectData/TypelessObjectData.cs
@@ -1,0 +1,39 @@
+﻿using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing typeless data.
+    /// </summary>
+    internal sealed class TypelessObjectData : BaseObjectData
+    {
+        private readonly IEnumerable<string[]> values;
+
+        /// <inheritdoc/>
+        protected override string[] Names { get; }
+
+        public TypelessObjectData(Serialization.SerializationFactory prefixFactory, string typeName, string[] names, IEnumerable<string[]> values)
+            : base(prefixFactory, typeName)
+        {
+            this.Names = names;
+            this.values = values;
+        }
+
+        /// <inheritdoc/>
+        protected override string[] GetValues(string valuePrefix) =>
+            this.values
+                .Select(values => GetValues(values))
+                .Select(values => values.AsCsv(valuePrefix, this.typeName))
+                .ToArray();
+
+        /// <summary>
+        /// Gets the specified <paramref name="values"/> as double-quoted strings.
+        /// </summary>
+        /// <param name="values">A <see cref="string[]"/> containing the values.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private static string[] GetValues(string[] values) =>
+            values
+                .Select(value => $"\"{value}\"")
+                .ToArray();
+    }
+}

--- a/Crowswood.CsvConverter/UserConfig/GlobalConfig.cs
+++ b/Crowswood.CsvConverter/UserConfig/GlobalConfig.cs
@@ -1,6 +1,9 @@
-﻿namespace Crowswood.CsvConverter.UserConfig
+﻿using Crowswood.CsvConverter.Interfaces;
+
+namespace Crowswood.CsvConverter.UserConfig
 {
-    internal sealed class GlobalConfig : BaseConfig
+    internal sealed class GlobalConfig : BaseConfig,
+        IGlobalConfig
     {
         public GlobalConfig(string name, string value) : base(name, value) { }
     }

--- a/Crowswood.CsvConverter/UserConfig/TypedConfig.cs
+++ b/Crowswood.CsvConverter/UserConfig/TypedConfig.cs
@@ -1,6 +1,9 @@
-﻿namespace Crowswood.CsvConverter.UserConfig
+﻿using Crowswood.CsvConverter.Interfaces;
+
+namespace Crowswood.CsvConverter.UserConfig
 {
-    internal sealed class TypedConfig : BaseConfig
+    internal sealed class TypedConfig : BaseConfig,
+        ITypedConfig
     {
         public string TypeName { get; }
 


### PR DESCRIPTION
[FEATURE][REFACTOR][TESTS] Add support for defining serialize elements via options

Refactor the Serialize nested classes to internal top-level classes.
Added second serialization interface purely for options:: IOptionSerialization. Refactor Serialization to implement both interfaces explicitly with common support functions.
Move GetValidConfigKeys method to ConfigHelper; was GetValidKeys in Serialization.BaseConfigData.
Added tests for each Options Serialize option.

[REFACTOR] Serializations to use serialization config data

Refactored serialization data classes into sub-folders. Added PrefixFactory class to allow deferred retrieval of prefixes from config data by metadata and object-data types.
Added UserConfigExtensions extension method class.
Refactored ConfigHandler methods to be mostly wrappers around ConfigHelper methods; moved most logic to ConfigHelper class to allow easier reuse.
Added IGlobalConfig  and ITypedConfig interfaces to simplify retrieval of global and typed config values by extensions methods. GlobalConfig and TypedConfig now implement those interfaces; and GlobalConfigData and TypedConfigData now implement IEnumerable of them.
Updated tests.

[TEST] Add tests

Add test for object data types with attributes on the class and properties.
Add test for metadata types with attributes on the class and properties.
Add test for mixed metadata via options and object data via fluent serialization.
Add Type extension method to retrieve property and attribute data based on a property array.

[FEATURE][TESTS] Add support for serializing metadata contained in attributes

Add SerializationExtensions.
Add to TypeExtensions support for retrieving attributes and their types from a type.
Rename Serialization.PrefixFactory to SerializationFactory to better represent its function.
Refactor metadata serialization classes to provide the metadata and object data type names.
Add non-generic TypedMetadataData abstract class to allow referencing the generic instances without needing to know their type parameter. Also provides the ability to create a generic instance by specifying the type rather than the type parameter.
Add non-generic TypedObjectData abstract class to allow referencing the generic instances without needing to know their type parameter.
Added to Serializer pre-serialization checks prior to performing the serialization. Adds in TypedMetadataData instances where the metadata is carried as attributes on the Type.
Added tests.