### PR TITLE
[REFACTOR] Replace code handling Attribute based metadata

### DIFF
--- a/Crowswood.CsvConverter/Serializations/Metadata/AttributeMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/AttributeMetadataData.cs
@@ -1,0 +1,49 @@
+﻿using Crowswood.CsvConverter.Extensions;
+
+namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// A sealed class for serializing metadata that is connected to its data object by virtue of 
+    /// being an <see cref="Attribute"/> attached to the data object <see cref="Type"/>.
+    /// </summary>
+    internal sealed class AttributeMetadataData : BaseMetadataData
+    {
+        private readonly Type objectType;
+
+        public AttributeMetadataData(Serialization.SerializationFactory factory, string dataTypeName, Type objectType)
+            : base(factory, dataTypeName) => this.objectType = objectType;
+
+        /// <inheritdoc/>
+        public override string[] Serialize() => 
+            this.objectType.GetAttributes()
+                .Select(metadata => new
+                {
+                    Metadata = metadata,
+                    Type = metadata.GetType()
+                })
+                .GroupBy(item => item.Type)
+                .Select(group => new 
+                { 
+                    Metadata = group.Select(item => item.Metadata), 
+                    OptionsMetadata = this.factory.Options.GetOptionMetadata(group.Key),
+                    Type = group.Key,
+                })
+                .Where(item => item.OptionsMetadata is not null)
+                .Select(item => Serialize(item.Metadata, item.OptionsMetadata!, item.Type))
+                .SelectMany(item => item)
+                .ToArray();
+
+        /// <summary>
+        /// Serializes the specified <paramref name="metadata"/> using the specified <paramref name="optionMetadata"/> 
+        /// and <paramref name="type"/>.
+        /// </summary>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="Attribute"/>.</param>
+        /// <param name="optionMetadata">An <see cref="OptionMetadata"/> instance.</param>
+        /// <param name="type">The <see cref="Type"/> of the <paramref name="metadata"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        private string[] Serialize(IEnumerable<Attribute> metadata, OptionMetadata optionMetadata, Type type) =>
+            Serialize(metadata,
+                      optionMetadata.Prefix,
+                      GetProperties(type, optionMetadata.PropertyNames));
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
@@ -1,11 +1,15 @@
-﻿namespace Crowswood.CsvConverter.Serializations
+﻿using System.Reflection;
+using Crowswood.CsvConverter.Extensions;
+using Crowswood.CsvConverter.Helpers;
+
+namespace Crowswood.CsvConverter.Serializations
 {
     /// <summary>
     /// An abstract base class for serializing metadata.
     /// </summary>
     internal abstract class BaseMetadataData : BaseSerializationData
     {
-        protected readonly Serialization.SerializationFactory prefixFactory;
+        protected readonly Serialization.SerializationFactory factory;
 
         /// <summary>
         /// The name of the type of the object data that this metadata is attached to.
@@ -13,19 +17,42 @@
         protected readonly string dataTypeName;
 
         /// <summary>
-        /// The name of the type of the metadata.
-        /// </summary>
-        internal abstract string MetadataTypeName { get; }
-
-        /// <summary>
         /// Gets the name of the object data type that this metadata is attached to.
         /// </summary>
         internal string ObjectDataTypeName => this.dataTypeName;
 
-        protected BaseMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName)
+        protected BaseMetadataData(Serialization.SerializationFactory factory, string dataTypeName)
         {
-            this.prefixFactory = prefixFactory;
+            this.factory = factory;
             this.dataTypeName = dataTypeName;
         }
+
+        /// <summary>
+        /// Gets the <see cref="PropertyInfo"/> from the specified <paramref name="type"/> that 
+        /// exist in the specified <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="MetadataType"/> to get the properties of.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        protected static PropertyInfo[] GetProperties(Type type, string[] propertyNames) =>
+            type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(property => property.CanRead && property.CanWrite)
+                .Where(property => propertyNames?.Contains(property.Name) ?? false)
+                .ToArray();
+
+        /// <summary>
+        /// Serializes the specified <paramref name="metadata"/> using the specified <paramref name="metadataPrefix"/> 
+        /// and <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/>.</param>
+        /// <param name="metadataPrefix">A <see cref="string"/> containing the metadata prefix.</param>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
+        /// <returns>A <see cref="string[]"/>.</returns>
+        protected string[] Serialize(IEnumerable<object> metadata, string metadataPrefix, PropertyInfo[] properties)=>
+            metadata
+                .Select(item => ConverterHelper.AsStrings(item, properties).ToArray())
+                .Where(values => values.Any())
+                .Select(values => values.AsCsv(metadataPrefix, this.dataTypeName))
+                .ToArray();
     }
 }

--- a/Crowswood.CsvConverter/Serializations/Metadata/SingleMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/SingleMetadataData.cs
@@ -1,0 +1,16 @@
+﻿namespace Crowswood.CsvConverter.Serializations
+{
+    /// <summary>
+    /// An abstract class for serializing a single data type of metadata.
+    /// </summary>
+    internal abstract class SingleMetadataData : BaseMetadataData
+    {
+        /// <summary>
+        /// The name of the type of the metadata.
+        /// </summary>
+        internal abstract string MetadataTypeName { get; }
+
+        protected SingleMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName)
+            : base(prefixFactory, dataTypeName) { }
+    }
+}

--- a/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
@@ -5,7 +5,7 @@ namespace Crowswood.CsvConverter.Serializations
     /// <summary>
     /// A sealed class for serializing typeless metadata.
     /// </summary>
-    internal sealed class TypelessMetadataData : BaseMetadataData
+    internal sealed class TypelessMetadataData : SingleMetadataData
     {
         private readonly string metadataPrefix;
         private readonly Dictionary<string, string> metadata;
@@ -23,7 +23,7 @@ namespace Crowswood.CsvConverter.Serializations
         public override string[] Serialize()
         {
             var optionMetadata =
-                this.prefixFactory.Options.GetOptionMetadata(metadataPrefix) ??
+                this.factory.Options.GetOptionMetadata(metadataPrefix) ??
                 throw new InvalidOperationException(
                     $"No Metadata definition in Options for a prefix of '{metadataPrefix}'.");
 


### PR DESCRIPTION
Add new metadata serialize data class to handle attribute defined metadata; supports multiple metadata data types from a single object data type. Add new class into hierarchy for single metadata data type that existing Typed and Typeless metadata classes derive from. Refactor to move common logic down to base metadata class. Remove PreSerializationAdjustments code from Serialization class. Instead add instance of AttributeMetadataData for each instance of TypedObjectData added to the serializations list.