### PR TITLE
[REFACTOR] Migrate code that requires System.Reflection away from main logic classes

### DIFF
--- a/Crowswood.CsvConverter/Converter.cs
+++ b/Crowswood.CsvConverter/Converter.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
+using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Interfaces;
@@ -266,16 +266,7 @@ namespace Crowswood.CsvConverter
                 ConverterHelper.GetTypeNames(lines,
                                               configHandler.GetPropertyPrefixes(),
                                               tn => configHandler.GetPropertyPrefix(tn));
-            var types =
-                Assembly.GetAssembly(typeof(TBase))?.GetTypes()
-                    .Select(type => new
-                    {
-                        Type = type,
-                        Attribute = type.GetCustomAttribute<CsvConverterClassAttribute>(),
-                    })
-                    .Where(n => typeNames.Contains(n.Type.Name) ||
-                                typeNames.Contains(n.Attribute?.Name))
-                    .Select(n => n.Type) ?? new List<Type>();
+            var types = typeof(TBase).GetTypes(typeNames);
             return types;
         }
 

--- a/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/OptionsExtensions.cs
@@ -85,6 +85,22 @@ namespace Crowswood.CsvConverter.Extensions
                 .FirstOrDefault(metadata => metadata.Type == type);
 
         /// <summary>
+        /// Gets the property names from the <paramref name="properties"/> with any conversions 
+        /// that are defined in the <seealso cref="options"/> or as an attribute on the member 
+        /// itself.
+        /// </summary>
+        /// <param name="properties">A <see cref="PropertyInfo[]"/> that contains the properties.</param>
+        /// <param name="options">The <see cref="Options"/> object.</param>
+        /// <returns>A <see cref="string[]"/> containing the names.</returns>
+        public static string[] GetParameters(this PropertyInfo[] properties, Options options) =>
+            properties
+                .Select(property =>
+                    options.GetOptionMember(property)?.Name ??
+                    property.GetCustomAttribute<CsvConverterPropertyAttribute>()?.Name ??
+                    property.Name)
+                .ToArray();
+
+        /// <summary>
         /// Retrieves the properties of the <seealso cref="OptionMetadata.Type"/> that match the
         /// <seealso cref="OptionMetadata.PropertyNames"/>.
         /// </summary>

--- a/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
+++ b/Crowswood.CsvConverter/Extensions/TypeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Reflection;
+using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Model;
 
 namespace Crowswood.CsvConverter.Extensions
@@ -7,6 +8,11 @@ namespace Crowswood.CsvConverter.Extensions
     /// <summary>
     /// An extension class for type extension methods.
     /// </summary>
+    /// <remarks>
+    /// This extension class only contains methods that extend <see cref="Type"/>. Any other 
+    /// extension methods that more generally support reflection should live in the 
+    /// <see cref="ReflectionExtensions"/> class.
+    /// </remarks>
     public static class TypeExtensions
     {
         /// <summary>
@@ -22,16 +28,6 @@ namespace Crowswood.CsvConverter.Extensions
         }
 
         /// <summary>
-        /// Gets the types of the <paramref name="attributes"/>.
-        /// </summary>
-        /// <param name="attributes">An <see cref="IEnumerable{T}"/> of <see cref="Attribute"/>.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Type"/>.</returns>
-        public static IEnumerable<Type> GetAttributeTypes(this IEnumerable<Attribute> attributes) =>
-            attributes
-                .Select(attribute => attribute.GetType())
-                .Distinct();
-
-        /// <summary>
         /// Extension method to determine and return the depth of the <see cref="Type"/> in the
         /// hierarchy.
         /// </summary>
@@ -41,13 +37,100 @@ namespace Crowswood.CsvConverter.Extensions
             type.BaseType is null ? 0 : type.BaseType.GetDepth() + 1;
 
         /// <summary>
-        /// Extension method to determine and return the depth of the type that declares the 
-        /// <paramref name="property"/>.
+        /// Retrieves an instance non-public generic method with a generic type parameter of
+        /// <typeparamref name="TParam"/>, has a name of <paramref name="name"/> and accepts the 
+        /// specified <paramref name="arguments"/> to process objects of type <paramref name="genericType"/>.
         /// </summary>
-        /// <param name="property">The <see cref="PropertyInfo"/>.</param>
-        /// <returns>An <see cref="int"/>.</returns>
-        public static int GetTypeDepth(this PropertyInfo property) =>
-            property.DeclaringType?.GetDepth() ?? 0;
+        /// <typeparam name="TParam">The generic type parameter to apply to the method.</typeparam>
+        /// <typeparam name="TReturn">The type of the return value of the method.</typeparam>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="genericType">A <see cref="Type"/> that indicates the type of object that the method will handle.</param>
+        /// <param name="arguments">An <see cref="object"/> array that contains the arguments to supply to the method.</param>
+        /// <returns>A <see cref="MethodInfo"/>.</returns>
+        public static MethodInfo GetGenericMethod(this Type type, string name, Type genericType, Type returnType, object[] arguments) =>
+            type.GetGenericMethod(name, genericType, returnType, arguments.Select(argument => argument.GetType()).ToArray());
+
+        /// <summary>
+        /// Retrieves an instance non-public generic method with a generic type parameter of
+        /// <typeparamref name="TParam"/>, has a name of <paramref name="name"/> and accepts the 
+        /// arguments of the specified <paramref name="argumentTypes"/> to process objects of type 
+        /// <paramref name="genericType"/>.
+        /// </summary>
+        /// <typeparam name="TParam">The generic type parameter to apply to the method.</typeparam>
+        /// <typeparam name="TReturn">The type of the return value of the method.</typeparam>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="genericType">A <see cref="Type"/> that indicates the type of object that the method will handle.</param>
+        /// <param name="argumentTypes">A <see cref="Type"/> array that contains the types of arguments to supply to the method.</param>
+        /// <returns>A <see cref="MethodInfo"/>.</returns>
+        /// <exception cref="InvalidOperationException">If the a matcing method is not found.</exception>
+        public static MethodInfo GetGenericMethod(this Type type, string name, Type genericType, Type returnType, Type[] argumentTypes) =>
+            type.GetGenericMethod(name,
+                                  BindingFlags.Instance |
+                                  BindingFlags.NonPublic,
+                                  genericType,
+                                  argumentTypes,
+                                  returnType) ??
+            throw new InvalidOperationException(
+                $"Failed to bind {ReflectionHelper.GetMethodSignature(name, genericType, returnType, argumentTypes)}.");
+
+        /// <summary>
+        /// Extension method to return a fully constructed generic method from the <paramref name="type"/>
+        /// that has the specified <paramref name="name"/> and matches the specified <paramref name="bindingFlags"/>,
+        /// for the specified <paramref name="genericType"/> that matches the specified 
+        /// <paramref name="argumentTypes"/> and <paramref name="returnType"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which to return the method.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="bindingFlags">The <see cref="BindingFlags"/> to use.</param>
+        /// <param name="genericType">The <see cref="Type"/> of the generic type.</param>
+        /// <param name="argumentTypes">A <see cref="Type[]"/> containing the argument types.</param>
+        /// <param name="returnType">The <see cref="Type"/> of the return type.</param>
+        /// <returns>A <see cref="MethodInfo"/> or null if the method is not found or could not be constructed.</returns>
+        public static MethodInfo? GetGenericMethod(this Type type,
+                                                   string name,
+                                                   BindingFlags bindingFlags,
+                                                   Type genericType,
+                                                   Type[] argumentTypes,
+                                                   Type returnType) =>
+            type.GetGenericMethod(name, bindingFlags, new[] { genericType }, argumentTypes, returnType);
+
+        /// <summary>
+        /// Extension method to return a fully constructed generic method from the <paramref name="type"/>
+        /// that has the specified <paramref name="name"/> and matches the specified <paramref name="bindingFlags"/>,
+        /// for the specified <paramref name="genericTypes"/> that matches the specified 
+        /// <paramref name="argumentTypes"/> and <paramref name="returnType"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> from which to return the method.</param>
+        /// <param name="name">A <see cref="string"/> that contains the name of the method.</param>
+        /// <param name="bindingFlags">The <see cref="BindingFlags"/> to use.</param>
+        /// <param name="genericTypes">A <see cref="Type[]"/> containing the generic types.</param>
+        /// <param name="argumentTypes">A <see cref="Type[]"/> containing the argument types.</param>
+        /// <param name="returnType">The <see cref="Type"/> of the return type.</param>
+        /// <returns>A <see cref="MethodInfo"/> or null if the method is not found or could not be constructed.</returns>
+        public static MethodInfo? GetGenericMethod(this Type type,
+                                                   string name,
+                                                   BindingFlags bindingFlags,
+                                                   Type[] genericTypes,
+                                                   Type[] argumentTypes,
+                                                   Type returnType)
+        {
+            // We need to check the method parameters AFTER constructing the generic method to be 
+            // able to check parameter types, otherwise any parameters based on the type-parameter
+            // won't have been constructed themselves. Because constructing a generic method is
+            // fairly heavy, we check the number of arguments match the number of types before
+            // doing the construction so that we can filter out any methods with the wrong number
+            // of parameters.
+            var methods =
+                type.GetMethods(bindingFlags)
+                    .Where(method => method.Name == name)
+                    .Select(method => method.ConstructGenericMethod(genericTypes))
+                    .NotNull()
+                    .Where(method => method.CheckArguments(argumentTypes, returnType))
+                    .ToList();
+            var method =
+                methods.Count == 1 ? methods.First() : null;
+            return method;
+        }
 
         /// <summary>
         /// Extension method to return the <see cref="Type"/> name in the standard readable form.
@@ -84,22 +167,116 @@ namespace Crowswood.CsvConverter.Extensions
                 .Select(property => new PropertyAndAttributePair(property));
 
         /// <summary>
-        /// Retrieves the <see cref="PropertyAndAttributePair"/> objects for the <paramref name="properties"/>.
+        /// Gets the properties of <paramref name="type"/> that occur in the specified <paramref name="propertyNames"/>.
         /// </summary>
-        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="PropertyAndAttributePair"/> objects.</returns>
-        public static IEnumerable<PropertyAndAttributePair> GetPropertyAndAttributePairs(this PropertyInfo[] properties) =>
-            properties
-                .Select(property => new PropertyAndAttributePair(property));
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        public static PropertyInfo[] GetPropertiesByName(this Type type, string[] propertyNames)
+        {
+            var properties = type.GetReadWriteProperties(propertyNames);
+
+            var results =
+                propertyNames
+                    .Select(propertyName =>
+                        properties
+                            .FirstOrDefault(property => property.Name == propertyName))
+                    .NotNull()
+                    .ToArray();
+            return results;
+        }
 
         /// <summary>
-        /// Convert the <paramref name="propertyAndAttributePairs"/> into an <see cref="IEnumerable{T}"/>
-        /// of <see cref="PropertyAndNamePair"/> objects.
+        /// Retrieves the public instance properties of <paramref name="type"/> that are both read 
+        /// and write.
         /// </summary>
-        /// <param name="propertyAndAttributePairs">An <see cref="IEnumerable{T}"/> of <see cref="PropertyAndAttributePair"/> objects.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="PropertyAndNamePair"/> objects.</returns>
-        public static IEnumerable<PropertyAndNamePair> GetPropertyAndNamePairs(this IEnumerable<PropertyAndAttributePair> propertyAndAttributePairs) =>
-            propertyAndAttributePairs
-                .Select(item => new PropertyAndNamePair(item));
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        public static PropertyInfo[] GetReadWriteProperties(this Type type) =>
+            type.GetProperties(BindingFlags.Instance |
+                               BindingFlags.Public)
+                .Where(property => property.CanRead && property.CanWrite)
+                .ToArray();
+
+        /// <summary>
+        /// Retrieves the public instance properties of <paramref name="type"/> that are both read 
+        /// and write and whos name is included in <paramref name="propertyNames"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <param name="propertyNames">A <see cref="string[]"/> that contains the property names.</param>
+        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
+        public static PropertyInfo[] GetReadWriteProperties(this Type type, string[] propertyNames) =>
+            type.GetReadWriteProperties()
+                .Where(property => propertyNames?.Contains(property.Name) ?? false)
+                .ToArray();
+
+        /// <summary>
+        /// Gets the public read/write properties that are supported for serialization for 
+        /// <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="PropertyInfo"/> array.</returns>
+        public static PropertyInfo[] GetReadWritePropertiesByDepth(this Type type) =>
+            type.GetReadWriteProperties()
+                .Where(property => property.PropertyType == typeof(string) ||
+                                   property.PropertyType.IsValueType &&
+                                   property.PropertyType != typeof(DateTime))
+                .Select(property => new { Property = property, Depth = property.GetTypeDepth(), })
+                .OrderBy(n => n.Depth)
+                .Select(n => n.Property)
+                .ToArray();
+
+        /// <summary>
+        /// Get the static string fields of <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="FieldInfo[]"/>.</returns>
+        public static FieldInfo[] GetStaticStringFields(this Type type) =>
+            type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(field => field.FieldType == typeof(string))
+                .ToArray();
+
+        /// <summary>
+        /// Gets the type name from either the <paramref name="type"/> or its 
+        /// <see cref="CsvConverterClassAttribute"/> if any.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <returns>A <see cref="string"/>.</returns>
+        public static string GetTypeName(this Type type) =>
+            type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
+            type.Name;
+
+        /// <summary>
+        /// Gets the types that exist in the <see cref="Assembly"/> that contains <paramref name="type"/>
+        /// that exist in the specified <paramref name="typeNames"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> that identifies the <see cref="Assembly"/>.</param>
+        /// <param name="typeNames">A <see cref="string[]"/> containing the names of the types to retrieve.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Type"/>.</returns>
+        public static Type[] GetTypes(this Type type, string[] typeNames) =>
+            Assembly.GetAssembly(type)?.GetTypes()
+                .Select(type => new
+                {
+                    Type = type,
+                    Attribute = type.GetCustomAttribute<CsvConverterClassAttribute>(),
+                })
+                .Where(item => typeNames.Contains(item.Type.Name) ||
+                               typeNames.Contains(item.Attribute?.Name))
+                .Select(item => item.Type)
+                .ToArray() ?? Array.Empty<Type>();
+
+        /// <summary>
+        /// Gets the types that exist in the <see cref="Assembly"/> that contains the <paramref name="type"/>
+        /// that have the specified <paramref name="typeName"/> and which can be assigned to the 
+        /// <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/>.</param>
+        /// <param name="typeName">A <see cref="string"/> containing the name of the desired type.</param>
+        /// <returns>A <see cref="Type[]"/>.</returns>
+        public static Type[] GetType(this Type type, string typeName) =>
+            Assembly.GetAssembly(type)?.GetTypes()
+                .Where(t => t.Name == typeName)
+                .Where(t => t.IsAssignableTo(type))
+                .ToArray() ?? Array.Empty<Type>();
     }
 }

--- a/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
+++ b/Crowswood.CsvConverter/Handlers/MetadataHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Reflection;
 using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Helpers;
 
@@ -122,9 +121,7 @@ namespace Crowswood.CsvConverter.Handlers
                 metadata
                     .Select(item => item as Attribute)
                     .NotNull()
-                    .Where(attribute =>
-                        attribute.GetType().GetCustomAttributes<AttributeUsageAttribute>(true)
-                            .Any(a => (a.ValidOn & AttributeTargets.Class) == AttributeTargets.Class))
+                    .Where(attribute => attribute.IsClassAttribute())
                     .ToArray();
             if (attributes.Any())
             {

--- a/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConfigHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Extensions;
+﻿using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Interfaces;
 using Crowswood.CsvConverter.UserConfig;
@@ -61,8 +60,7 @@ namespace Crowswood.CsvConverter.Helpers
         /// <param name="type">A <see cref="Type"/>.</param>
         /// <returns>A <see cref="string[]"/>.</returns>
         public static string[] GetValidConfigKeys(Type type) =>
-            type.GetFields(BindingFlags.Public | BindingFlags.Static)
-                .Where(field => field.FieldType == typeof(string))
+            type.GetStaticStringFields()
                 .Select(field => field.GetValue(null))
                 .Cast<string>()
                 .ToArray();

--- a/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
+++ b/Crowswood.CsvConverter/Helpers/ConverterHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Model;
+﻿using Crowswood.CsvConverter.Model;
 
 namespace Crowswood.CsvConverter.Helpers
 {
@@ -9,23 +8,13 @@ namespace Crowswood.CsvConverter.Helpers
     internal static class ConverterHelper
     {
         /// <summary>
-        /// Converts and returns the values of the properties of the specified <paramref name="item"/> 
-        /// that are in the <paramref name="properties"/> into an <see cref="IEnumerable{T}"/> of 
-        /// <see cref="string"/>.
+        /// Converts and returns the values of the specified <paramref name="items"/> as strings 
+        /// according to their <see cref="Type"/>.
         /// </summary>
-        /// <typeparam name="TBase">The type of item to process.</typeparam>
-        /// <param name="item">A <typeparamref name="TBase"/> object.</param>
-        /// <param name="properties">A <see cref="PropertyInfo"/> array.</param>
+        /// <param name="items">An <see cref="IEnumerable{T}"/> of <see cref="Type"/> and <see cref="object"/>.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
-        internal static IEnumerable<string> AsStrings<TBase>(TBase item, PropertyInfo[] properties)
-            where TBase : class =>
-            properties
-                .Select(property => new 
-                {
-                    Type = property.PropertyType,
-                    Value = property.GetValue(item),
-                })
-                .Select(item => GetText(item.Type, item.Value?.ToString()));
+        internal static IEnumerable<string> AsStrings(IEnumerable<(Type Type, object? Value)> items) =>
+            items.Select(item => GetText(item.Type, item.Value?.ToString()));
 
         /// <summary>
         /// Format the specified <paramref name="prefix"/>, <paramref name="typeName"/> and 
@@ -79,40 +68,40 @@ namespace Crowswood.CsvConverter.Helpers
                 .Select(items => items[2..^0])
                 .FirstOrDefault();
 
-        /// <summary>
-        /// Attempts to identify and return a <see cref="PropertyInfo"/> associated with the 
-        /// specified <paramref name="name"/> using the specified <paramref name="members"/> and 
-        /// <paramref name="propertyAndNamePairs"/>.
-        /// </summary>
-        /// <param name="members">An <see cref="OptionMember"/> array.</param>
-        /// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
-        /// <param name="name">A <see cref="string"/> containing the name.</param>
-        /// <returns>A <see cref="PropertyInfo"/> or null if none match.</returns>
-        /// <remarks>
-        /// Attempt to find the property in this order:
-        /// <list type="number">
-        /// <item>by option assignment; this overrides all others.</item>
-        /// <item>by defined name.</item>
-        /// <item>by property name.</item>
-        /// </list>
-        /// otherwise ignore it.
-        /// In all instances the name must match exactly, including case.
-        /// </remarks>
-        internal static PropertyInfo? GetProperty(OptionMember[] members,
-                                                  IEnumerable<PropertyAndNamePair> propertyAndNamePairs,
-                                                  string name) =>
-            members
-                .Where(member => member.Name == name)
-                .Select(member => member.Property)
-                .FirstOrDefault() ??
-            propertyAndNamePairs
-                .Where(item => item.Name == name)
-                .Select(item => item.Property)
-                .FirstOrDefault() ??
-            propertyAndNamePairs
-                .Where(item => item.Property.Name == name)
-                .Select(item => item.Property)
-                .FirstOrDefault();
+        ///// <summary>
+        ///// Attempts to identify and return a <see cref="PropertyInfo"/> associated with the 
+        ///// specified <paramref name="name"/> using the specified <paramref name="members"/> and 
+        ///// <paramref name="propertyAndNamePairs"/>.
+        ///// </summary>
+        ///// <param name="members">An <see cref="OptionMember"/> array.</param>
+        ///// <param name="propertyAndNamePairs">A <see cref="List{T}"/> of <see cref="PropertyAndNamePair"/> objects.</param>
+        ///// <param name="name">A <see cref="string"/> containing the name.</param>
+        ///// <returns>A <see cref="PropertyInfo"/> or null if none match.</returns>
+        ///// <remarks>
+        ///// Attempt to find the property in this order:
+        ///// <list type="number">
+        ///// <item>by option assignment; this overrides all others.</item>
+        ///// <item>by defined name.</item>
+        ///// <item>by property name.</item>
+        ///// </list>
+        ///// otherwise ignore it.
+        ///// In all instances the name must match exactly, including case.
+        ///// </remarks>
+        //internal static PropertyInfo? GetProperty(OptionMember[] members,
+        //                                          IEnumerable<PropertyAndNamePair> propertyAndNamePairs,
+        //                                          string name) =>
+        //    members
+        //        .Where(member => member.Name == name)
+        //        .Select(member => member.Property)
+        //        .FirstOrDefault() ??
+        //    propertyAndNamePairs
+        //        .Where(item => item.Name == name)
+        //        .Select(item => item.Property)
+        //        .FirstOrDefault() ??
+        //    propertyAndNamePairs
+        //        .Where(item => item.Property.Name == name)
+        //        .Select(item => item.Property)
+        //        .FirstOrDefault();
 
         /// <summary>
         /// Gets the names of the data-types from the specified <paramref name="lines"/> using the 

--- a/Crowswood.CsvConverter/Options/OptionType.cs
+++ b/Crowswood.CsvConverter/Options/OptionType.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-
-namespace Crowswood.CsvConverter
+﻿namespace Crowswood.CsvConverter
 {
     /// <summary>
     /// An abstract base class that allows a type to be added to an <see cref="options"/>

--- a/Crowswood.CsvConverter/Processors/DeserializationProcessor.cs
+++ b/Crowswood.CsvConverter/Processors/DeserializationProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Extensions;
+﻿using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Handlers;
 using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Model;
@@ -148,12 +147,8 @@ namespace Crowswood.CsvConverter.Processors
         private IEnumerable<TBase> ConvertTo<TBase>(string typeName, (string[], IEnumerable<string[]>) data)
             where TBase : class
         {
-            var types =
-                Assembly.GetAssembly(typeof(TBase))?.GetTypes()
-                    .Where(type => type.Name == typeName)
-                    .Where(type => type.IsAssignableTo(typeof(TBase)))
-                    .ToList() ?? new List<Type>();
-            if (types.Count > 1)
+            var types = typeof(TBase).GetType(typeName);
+            if (types.Length > 1)
                 throw new InvalidOperationException(
                     $"Unable to identify exactly one type called '{typeName}' from the assembly containing '{typeof(TBase).Name}'.");
             var type =
@@ -231,9 +226,7 @@ namespace Crowswood.CsvConverter.Processors
         /// <remarks>Used when deserializing into typeless data before converting to typed data.</remarks>
         private TypelessData? ConvertTo(Type type, IEnumerable<string> lines)
         {
-            var typeName =
-                type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-                type.Name;
+            var typeName = type.GetTypeName();
 
             var propertyAndNamePairs =
                 type.GetPropertyAndAttributePairs()

--- a/Crowswood.CsvConverter/Serialization.cs
+++ b/Crowswood.CsvConverter/Serialization.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Extensions;
+﻿using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Helpers;
 using Crowswood.CsvConverter.Interfaces;
 using Crowswood.CsvConverter.Serializations;
@@ -252,7 +251,7 @@ namespace Crowswood.CsvConverter
             where TObject : class => TypedMetadata<TMetadata>(GetTypeName<TObject>(), metadata);
 
         private Serialization TypedMetadata<TMetadata>(Type dataType, IEnumerable<TMetadata> metadata) 
-            where TMetadata : class => TypedMetadata<TMetadata>(GetTypeName(dataType), metadata);
+            where TMetadata : class => TypedMetadata<TMetadata>(dataType.GetTypeName(), metadata);
 
         private Serialization TypedMetadata<TMetadata>(string dataTypeName, IEnumerable<TMetadata> metadata)
             where TMetadata : class => Add(new TypedMetadataData<TMetadata>(new SerializationFactory(this), dataTypeName, metadata));
@@ -261,7 +260,7 @@ namespace Crowswood.CsvConverter
             where TObject : class => TypelessMetadata(GetTypeName<TObject>(), metadataPrefix, metadata);
 
         private Serialization TypelessMetadata(Type dataType, string metadataPrefix, Dictionary<string, string> metadata) =>
-            TypelessMetadata(GetTypeName(dataType), metadataPrefix, metadata);
+            TypelessMetadata(dataType.GetTypeName(), metadataPrefix, metadata);
 
         private Serialization TypelessMetadata(string dataTypeName, string metadataPrefix, Dictionary<string, string> metadata) =>
             Add(new TypelessMetadataData(new SerializationFactory(this), dataTypeName, metadataPrefix, metadata));
@@ -299,17 +298,7 @@ namespace Crowswood.CsvConverter
         /// </summary>
         /// <typeparam name="T">The type of object.</typeparam>
         /// <returns>A <see cref="string"/>.</returns>
-        private static string GetTypeName<T>() => GetTypeName(typeof(T));
-
-        /// <summary>
-        /// Gets the type name from either the specified <paramref name="type"/> or its 
-        /// <see cref="CsvConverterClassAttribute"/> if any.
-        /// </summary>
-        /// <param name="type">A <see cref="Type"/>.</param>
-        /// <returns>A <see cref="string"/>.</returns>
-        private static string GetTypeName(Type type) =>
-            type.GetCustomAttribute<CsvConverterClassAttribute>()?.Name ??
-            type.Name;
+        private static string GetTypeName<T>() => typeof(T).GetTypeName();
 
         /// <summary>
         /// Serialize the <seealso cref="serializations"/> preceeded by the specified <paramref name="preceedingData"/> 

--- a/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/BaseMetadataData.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Extensions;
+﻿using Crowswood.CsvConverter.Extensions;
 using Crowswood.CsvConverter.Helpers;
 
 namespace Crowswood.CsvConverter.Serializations
@@ -12,47 +11,28 @@ namespace Crowswood.CsvConverter.Serializations
         protected readonly Serialization.SerializationFactory factory;
 
         /// <summary>
-        /// The name of the type of the object data that this metadata is attached to.
-        /// </summary>
-        protected readonly string dataTypeName;
-
-        /// <summary>
         /// Gets the name of the object data type that this metadata is attached to.
         /// </summary>
-        internal string ObjectDataTypeName => this.dataTypeName;
+        internal string ObjectDataTypeName { get; }
 
         protected BaseMetadataData(Serialization.SerializationFactory factory, string dataTypeName)
         {
             this.factory = factory;
-            this.dataTypeName = dataTypeName;
+            this.ObjectDataTypeName = dataTypeName;
         }
 
         /// <summary>
-        /// Gets the <see cref="PropertyInfo"/> from the specified <paramref name="type"/> that 
-        /// exist in the specified <paramref name="propertyNames"/>.
+        /// Serializes the specified <paramref name="metadata"/> using the specified <paramref name="metadataPrefix"/>.
         /// </summary>
-        /// <param name="type">The <see cref="MetadataType"/> to get the properties of.</param>
-        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
-        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
-        protected static PropertyInfo[] GetProperties(Type type, string[] propertyNames) =>
-            type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Where(property => property.CanRead && property.CanWrite)
-                .Where(property => propertyNames?.Contains(property.Name) ?? false)
-                .ToArray();
-
-        /// <summary>
-        /// Serializes the specified <paramref name="metadata"/> using the specified <paramref name="metadataPrefix"/> 
-        /// and <paramref name="properties"/>.
-        /// </summary>
-        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/>.</param>
+        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="IEnumerable{T}"/> of <see cref="Type"/> and <see cref="object"/> that contains the metadata.</param>
         /// <param name="metadataPrefix">A <see cref="string"/> containing the metadata prefix.</param>
-        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
         /// <returns>A <see cref="string[]"/>.</returns>
-        protected string[] Serialize(IEnumerable<object> metadata, string metadataPrefix, PropertyInfo[] properties)=>
+        protected string[] Serialize(IEnumerable<IEnumerable<(Type Type, object? Value)>> metadata, string metadataPrefix) =>
             metadata
-                .Select(item => ConverterHelper.AsStrings(item, properties).ToArray())
+                .Select(items => ConverterHelper.AsStrings(items))
+                .Select(values => values.ToArray())
                 .Where(values => values.Any())
-                .Select(values => values.AsCsv(metadataPrefix, this.dataTypeName))
+                .Select(values => values.AsCsv(metadataPrefix, this.ObjectDataTypeName))
                 .ToArray();
     }
 }

--- a/Crowswood.CsvConverter/Serializations/Metadata/TypedMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/TypedMetadataData.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Crowswood.CsvConverter.Extensions;
+﻿using Crowswood.CsvConverter.Extensions;
 
 namespace Crowswood.CsvConverter.Serializations
 {
@@ -15,77 +14,6 @@ namespace Crowswood.CsvConverter.Serializations
 
         protected TypedMetadataData(Serialization.SerializationFactory prefixFactory, string dataTypeName)
             : base(prefixFactory, dataTypeName) { }
-
-        /// <summary>
-        /// Creates and returns an instance of <see cref="TypedMetadataData{TMetadata}"/> for the 
-        /// specified <paramref name="metadataType"/> using the specified <paramref name="serialization"/> 
-        /// and <paramref name="dataTypeName"/> that serializes the specified <paramref name="metadata"/>.
-        /// </summary>
-        /// <param name="metadataType">A <see cref="Type"/> that defines the type of the metadata.</param>
-        /// <param name="serialization">The <see cref="Serialization"/> instance that the new instance will belong to.</param>
-        /// <param name="dataTypeName">A <see cref="string"/> that contains the name of the data object type.</param>
-        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/> that contains the metadata; each element must be able to be assigned to <paramref name="metadataType"/>.</param>
-        /// <returns>A <see cref="TypedMetadataData"/> instance.</returns>
-        /// <exception cref="InvalidOperationException">If an instance cannot be created.</exception>
-        /// <remarks>
-        /// Calls <seealso cref="Create{TMetadata}(Serialization.SerializationFactory, string, IEnumerable{object})"/>
-        /// by reflection.
-        /// </remarks>
-        internal static TypedMetadataData Create(Type metadataType,
-                                                 Serialization serialization,
-                                                 string dataTypeName,
-                                                 IEnumerable<object> metadata)
-        {
-            var parameters =
-                new object[]
-                {
-                    new Serialization.SerializationFactory(serialization),
-                    dataTypeName,
-                    metadata,
-                };
-
-            var method =
-                typeof(TypedMetadataData).GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-                    .Where(method => method.Name == "Create")
-                    .Where(method => method.IsGenericMethod)
-                    .SingleOrDefault()?.MakeGenericMethod(metadataType);
-
-            var result =
-                method?.Invoke(null, parameters) ??
-                throw new InvalidOperationException(
-                    $"Failed to bind to {nameof(TypedMetadataData)}<{metadataType.Name}>.");
-
-            return (TypedMetadataData)result;
-        }
-
-        /// <summary>
-        /// Creates and returns an instance of <see cref="TypedMetadataData{TMetadata}"/> for the 
-        /// specified <typeparamref name="TMetadata"/> using the specified <paramref name="factory"/>, 
-        /// and <paramref name="dataTypeName"/> that serializes the specified <paramref name="metadata"/>.
-        /// </summary>
-        /// <typeparam name="TMetadata">The type of the metadata.</typeparam>
-        /// <param name="factory">A <see cref="Serialization.SerializationFactory"/> object.</param>
-        /// <param name="dataTypeName">A <see cref="string"/> that contains the name of the data object type.</param>
-        /// <param name="metadata">An <see cref="IEnumerable{T}"/> of <see cref="object"/> that contains the metadata; each element must be able to be assigned to <paramref name="metadataType"/>.</param>
-        /// <returns>A <see cref="TypedMetadataData"/> instance.</returns>
-        /// <remarks>
-        /// Method is called using reflection by <seealso cref="Create(Type, Serialization, string, IEnumerable{object})"/>
-        /// </remarks>
-        private static TypedMetadataData Create<TMetadata>(Serialization.SerializationFactory factory,
-                                                           string dataTypeName,
-                                                           IEnumerable<object> metadata)
-            where TMetadata : class
-        {
-            var typedMetadata =
-                metadata
-                    .Where(md => md.GetType().IsAssignableTo(typeof(TMetadata)))
-                    .Cast<TMetadata>()
-                    .ToList();
-
-            var result =
-                new TypedMetadataData<TMetadata>(factory, dataTypeName, typedMetadata);
-            return result;
-        }
     }
 
     /// <summary>
@@ -105,59 +33,22 @@ namespace Crowswood.CsvConverter.Serializations
             : base(factory, dataTypeName) => this.metadata = metadata;
 
         /// <inheritdoc/>
-        public override string[] Serialize() =>
-            Serialize(
+        public override string[] Serialize()
+        {
+            var optionMetadata =
                 this.factory.Options.GetOptionMetadata(this.MetadataType) ??
                 throw new InvalidOperationException(
-                    $"No Metadata definition in Options for '{this.MetadataTypeName}'."));
+                    $"No Metadata definition in Options for '{this.MetadataTypeName}'.");
 
-        /// <summary>
-        /// Gets the <see cref="PropertyInfo"/> from <typeparamref name="T"/> that exist in the 
-        /// specified <paramref name="propertyNames"/>.
-        /// </summary>
-        /// <typeparam name="T">The <see cref="MetadataType"/> to get the properties of.</typeparam>
-        /// <param name="propertyNames">A <see cref="string[]"/> containing the property names.</param>
-        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
-        private static PropertyInfo[] GetProperties<T>(string[] propertyNames) => 
-            GetProperties(typeof(T), propertyNames);
+            var properties = typeof(TMetadata).GetPropertiesByName(optionMetadata.PropertyNames);
 
-        /// <summary>
-        /// Gets the <see cref="PropertyInfo"/> from the specified <paramref name="properties"/> 
-        /// according to the order defined in the specified <paramref name="propertyNames"/>.
-        /// </summary>
-        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
-        /// <param name="propertyNames">A <see cref="string[]"/> contains the names of the property names.</param>
-        /// <returns>A <see cref="PropertyInfo[]"/>.</returns>
-        /// <remarks>
-        /// The values must be in the order defined in the Options Metadata, so derive them from 
-        /// the PropertyNames, rather than directly from the properties of the Type.
-        /// </remarks>
-        private static PropertyInfo[] GetProperties(PropertyInfo[] properties, string[] propertyNames) =>
-            propertyNames
-                .Select(propertyName =>
-                    properties
-                        .FirstOrDefault(property => property.Name == propertyName))
-                .NotNull()
-                .ToArray();
+            var metadata =
+                this.metadata
+                    .Select(value => value.AsStrings(properties));
 
-        /// <summary>
-        /// Serializes the <seealso cref="metadata"/> using the specified <paramref name="optionMetadata"/> 
-        /// </summary>
-        /// <param name="optionMetadata"></param>
-        /// <returns>A <see cref="string[]"/>.</returns>
-        private string[] Serialize(OptionMetadata optionMetadata) =>
-            Serialize(optionMetadata, GetProperties<TMetadata>(optionMetadata.PropertyNames));
-
-        /// <summary>
-        /// Serializes the <seealso cref="metadata"/> using the specified <paramref name="optionMetadata"/> 
-        /// and <paramref name="properties"/>.
-        /// </summary>
-        /// <param name="optionMetadata"></param>
-        /// <param name="properties">A <see cref="PropertyInfo[]"/>.</param>
-        /// <returns>A <see cref="string[]"/>.</returns>
-        private string[] Serialize(OptionMetadata optionMetadata, PropertyInfo[] properties) =>
-            Serialize(this.metadata,
-                      optionMetadata.Prefix,
-                      GetProperties(properties, optionMetadata.PropertyNames));
+            var result = Serialize(metadata, optionMetadata.Prefix);
+            //var result = Serialize(this.metadata, optionMetadata.Prefix, properties);
+            return result;
+        }
     }
 }

--- a/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
+++ b/Crowswood.CsvConverter/Serializations/Metadata/TypelessMetadataData.cs
@@ -29,7 +29,7 @@ namespace Crowswood.CsvConverter.Serializations
 
             var result = 
                 GetValues(this.metadata, optionMetadata.PropertyNames)
-                    .AsCsv(optionMetadata.Prefix, this.dataTypeName);
+                    .AsCsv(optionMetadata.Prefix, this.ObjectDataTypeName);
 
             return new[] { result, };
         }


### PR DESCRIPTION
As much as possible conctrated code that uses System.Reflection into extension method classes and model classes. Created additional extension methods to support this. Rationalised the split of methods between ReflectionExtensions and TypeExtension classes.